### PR TITLE
Article navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+
+- Article navigation bar based on the headers present in the page.
 
 ## [0.8.0] - 2019-07-18
 ### Added

--- a/messages/en.json
+++ b/messages/en.json
@@ -17,5 +17,6 @@
   "docs/see-all": "See all",
   "docs/build": "Build with IO",
   "docs/create-stores": "Create stores on IO with Store Framework",
-  "docs/our-components": "Our components"
+  "docs/our-components": "Our components",
+  "docs/article-nav": "On this section"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -17,5 +17,6 @@
   "docs/see-all": "See all",
   "docs/build": "Build with IO",
   "docs/create-stores": "Create stores on IO with Store Framework",
-  "docs/our-components": "Our components"
+  "docs/our-components": "Our components",
+  "docs/article-nav": "On this section"
 }

--- a/react/Home.tsx
+++ b/react/Home.tsx
@@ -1,15 +1,23 @@
 import React, { Fragment, FunctionComponent } from 'react'
+import { FormattedMessage, injectIntl, InjectedIntlProps } from 'react-intl'
 import { Helmet, NoSSR } from 'vtex.render-runtime'
 
 import Footer from './components/Footer'
 import HomeSideBar from './components/HomeSidebar'
 import LatestFeatures from './components/LatestFeatures'
 import Community from './components/Community'
+import ArticleNav from './components/ArticleNav'
+import { slug } from './utils'
 
 import favicon from './images/favicon.png'
-import { FormattedMessage } from 'react-intl'
 
-const Home: FunctionComponent<any> = () => {
+const Home: FunctionComponent<InjectedIntlProps> = ({ intl }) => {
+  const homeHeadings = [
+    intl.formatMessage({ id: 'docs/build' }),
+    intl.formatMessage({ id: 'docs/latest-features' }),
+    intl.formatMessage({ id: 'docs/community-help' }),
+  ]
+
   return (
     <Fragment>
       <Helmet>
@@ -25,80 +33,87 @@ const Home: FunctionComponent<any> = () => {
           </div>
         </NoSSR>
         <div className="w-100">
-          <main className="w-80 flex">
-            <div className="pv9">
-              <h1 className="t-heading-1 normal c-emphasis w-90 w-80-ns center mb6">
-                <FormattedMessage id="docs/build" />
-              </h1>
-              <p className="small c-on-base w-90 w-80-ns center mb8">
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-                eiusmod.
-              </p>
-              <div className="w-90 w-80-ns center">
-                <div className="flex w-100">
-                  <div
-                    className="pa5 bg-muted-5 flex flex-column justify-end"
-                    style={{ width: '242px', height: '330px' }}>
-                    <p className="t-small ttu">
-                      <strong>
-                        <FormattedMessage id="docs/getting-started" />
-                      </strong>
-                    </p>
-                    <p className="t-heading-4 mv3 normal">
-                      <FormattedMessage id="docs/create-stores" />
-                    </p>
+          <div className="flex">
+            <main className="flex w-80">
+              <div className="pv9">
+                <h1
+                  id={slug(intl.formatMessage({ id: 'docs/build' }))}
+                  className="t-heading-1 normal c-emphasis w-90 w-80-ns center mb6">
+                  <FormattedMessage id="docs/build" />
+                </h1>
+                <p className="small c-on-base w-90 w-80-ns center mb8">
+                  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                  do eiusmod.
+                </p>
+                <div className="w-90 w-80-ns center">
+                  <div className="flex w-100">
+                    <div
+                      className="pa5 bg-muted-5 flex flex-column justify-end"
+                      style={{ width: '242px', height: '330px' }}>
+                      <p className="t-small ttu">
+                        <strong>
+                          <FormattedMessage id="docs/getting-started" />
+                        </strong>
+                      </p>
+                      <p className="t-heading-4 mv3 normal">
+                        <FormattedMessage id="docs/create-stores" />
+                      </p>
+                    </div>
+                    <div
+                      className="pa5 bg-muted-3"
+                      style={{ width: '517px', height: '330px' }}
+                    />
                   </div>
-                  <div
-                    className="pa5 bg-muted-3"
-                    style={{ width: '517px', height: '330px' }}
-                  />
+                  <div className="mv6 flex justify-around">
+                    <div>
+                      <div
+                        className="bg-muted-4"
+                        style={{ width: '242px', height: '120px' }}
+                      />
+                      <p className="t-heading-4">
+                        <FormattedMessage id="docs/recipes" />
+                      </p>
+                      <p className="c-muted-1">
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+                        sed do eiusmod.
+                      </p>
+                    </div>
+                    <div className="mh3">
+                      <div
+                        className="bg-muted-4"
+                        style={{ width: '242px', height: '120px' }}
+                      />
+                      <p className="t-heading-4">
+                        <FormattedMessage id="docs/our-components" />
+                      </p>
+                      <p className="c-muted-1">
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+                        sed do eiusmod.
+                      </p>
+                    </div>
+                    <div>
+                      <div
+                        className="bg-muted-4"
+                        style={{ width: '242px', height: '120px' }}
+                      />
+                      <p className="t-heading-4">
+                        <FormattedMessage id="docs/resources" />
+                      </p>
+                      <p className="c-muted-1">
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+                        sed do eiusmod.
+                      </p>
+                    </div>
+                  </div>
+                  <LatestFeatures />
+                  <Community />
                 </div>
-                <div className="mv6 flex justify-around">
-                  <div>
-                    <div
-                      className="bg-muted-4"
-                      style={{ width: '242px', height: '120px' }}
-                    />
-                    <p className="t-heading-4">
-                      <FormattedMessage id="docs/recipes" />
-                    </p>
-                    <p className="c-muted-1">
-                      Lorem ipsum dolor sit amet, consectetur adipiscing elit,
-                      sed do eiusmod.
-                    </p>
-                  </div>
-                  <div className="mh3">
-                    <div
-                      className="bg-muted-4"
-                      style={{ width: '242px', height: '120px' }}
-                    />
-                    <p className="t-heading-4">
-                      <FormattedMessage id="docs/our-components" />
-                    </p>
-                    <p className="c-muted-1">
-                      Lorem ipsum dolor sit amet, consectetur adipiscing elit,
-                      sed do eiusmod.
-                    </p>
-                  </div>
-                  <div>
-                    <div
-                      className="bg-muted-4"
-                      style={{ width: '242px', height: '120px' }}
-                    />
-                    <p className="t-heading-4">
-                      <FormattedMessage id="docs/resources" />
-                    </p>
-                    <p className="c-muted-1">
-                      Lorem ipsum dolor sit amet, consectetur adipiscing elit,
-                      sed do eiusmod.
-                    </p>
-                  </div>
-                </div>
-                <LatestFeatures />
-                <Community />
               </div>
+            </main>
+            <div className="pv9">
+              <ArticleNav headings={homeHeadings} />
             </div>
-          </main>
+          </div>
           <Footer />
         </div>
       </div>
@@ -106,4 +121,4 @@ const Home: FunctionComponent<any> = () => {
   )
 }
 
-export default Home
+export default injectIntl(Home)

--- a/react/components/ArticleNav.tsx
+++ b/react/components/ArticleNav.tsx
@@ -1,0 +1,36 @@
+import React, { FunctionComponent, Fragment } from 'react'
+import { FormattedMessage } from 'react-intl'
+import AnchorLink from 'react-anchor-link-smooth-scroll'
+
+import { slug } from '../utils'
+
+interface Props {
+  headings: string[]
+}
+
+const ArticleNav: FunctionComponent<Props> = ({ headings }) => (
+  <nav className="pa5 flex flex-column t-small">
+    <p className="ttu">
+      <strong>
+        <FormattedMessage id="docs/article-nav" />
+      </strong>
+    </p>
+    <Fragment>
+      {headings.map(heading => {
+        const slugifiedHeader = slug(heading)
+
+        return (
+          <AnchorLink
+            className="link no-underline"
+            offset={() => 80}
+            href={`#${slugifiedHeader}`}
+            key={slugifiedHeader}>
+            <p className="c-muted-2">{heading}</p>
+          </AnchorLink>
+        )
+      })}
+    </Fragment>
+  </nav>
+)
+
+export default ArticleNav

--- a/react/components/Community.tsx
+++ b/react/components/Community.tsx
@@ -1,9 +1,13 @@
-import React from 'react'
-import { FormattedMessage } from 'react-intl'
+import React, { FunctionComponent } from 'react'
+import { FormattedMessage, injectIntl, InjectedIntlProps } from 'react-intl'
 
-const Community = () => (
+import { slug } from '../utils'
+
+const Community: FunctionComponent<InjectedIntlProps> = ({ intl }) => (
   <section className="mv9">
-    <h2 className="t-heading-2 normal">
+    <h2
+      id={slug(intl.formatMessage({ id: 'docs/community-help' }))}
+      className="t-heading-2 normal">
       <FormattedMessage id="docs/community-help" />
     </h2>
     <div className="flex items-center">
@@ -21,4 +25,4 @@ const Community = () => (
   </section>
 )
 
-export default Community
+export default injectIntl(Community)

--- a/react/components/CustomTags.tsx
+++ b/react/components/CustomTags.tsx
@@ -2,11 +2,33 @@ import React from 'react'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 import { coy } from 'react-syntax-highlighter/dist/styles/prism'
 import AnchorLink from 'react-anchor-link-smooth-scroll'
-import slugify from 'slugify'
-
 import { useRuntime } from 'vtex.render-runtime'
 
+import ArticleNav from './ArticleNav'
+import { slug } from '../utils'
+
 export const CustomRenderers = {
+  root: ({ children }: any) => {
+    const TOCLines: string[] = children.reduce(
+      (acc: any, { key, props }: any) => {
+        // Skip non-headings and H1's
+        if (key.indexOf('heading') !== 0 || props.level === 1) {
+          return acc
+        }
+
+        const { value } = props.children[0].props
+        return acc.concat([`${value}`])
+      },
+      []
+    )
+
+    return (
+      <div className="flex">
+        <div className="flex flex-column w-70">{children}</div>
+        <ArticleNav headings={TOCLines} />
+      </div>
+    )
+  },
   break: () => <br />,
   code: (props: any) => {
     const codeBlock = props.value.replace(/“/gm, '"').replace(/”/gm, '"')
@@ -73,7 +95,7 @@ export const CustomRenderers = {
   },
   image: (props: any) => (
     <span className="mv5 mh0">
-      <img className="db center mv9 shadow-4" src={props.src} alt={props.alt} />
+      <img className="shadow-4" src={props.src} alt={props.alt} />
     </span>
   ),
   inlineCode: (props: any) => (
@@ -146,12 +168,6 @@ export const CustomRenderers = {
   },
   tableRow: (props: any) => <tr className="bb b--muted-3">{props.children}</tr>,
   thematicBreak: () => <hr className="mv7" />,
-}
-
-function slug(str: string) {
-  const replaced = (str && str.replace(/[*+~.()'"!:@&[\]]/g, '')) || ''
-  const slugified = slugify(replaced, { lower: true }) || ''
-  return slugified
 }
 
 function getHeadingSlug(childNodes: any) {

--- a/react/components/DocsRenderer.tsx
+++ b/react/components/DocsRenderer.tsx
@@ -52,7 +52,7 @@ const DocsRenderer: FunctionComponent = () => {
             />
             {meta.git && (
               <a href={meta.git}>
-                <FormattedMessage id="docs.docs-renderer.github" />
+                <FormattedMessage id="docs/renderer-github" />
               </a>
             )}
           </article>

--- a/react/components/LatestFeatures.tsx
+++ b/react/components/LatestFeatures.tsx
@@ -1,13 +1,15 @@
-import React from 'react'
-import slugify from 'slugify'
+import React, { FunctionComponent } from 'react'
+import { FormattedMessage, InjectedIntlProps, injectIntl } from 'react-intl'
 
+import { slug } from '../utils'
 import { latest } from '../content/Latest'
 import RightArrow from './icons/RightArrow'
-import { FormattedMessage } from 'react-intl'
 
-const LatestFeatures = () => (
+const LatestFeatures: FunctionComponent<InjectedIntlProps> = ({ intl }) => (
   <section className="mv9">
-    <h2 className="t-heading-2 normal mv4">
+    <h2
+      id={slug(intl.formatMessage({ id: 'docs/latest-features' }))}
+      className="t-heading-2 normal mv4">
       <FormattedMessage id="docs/latest-features" />
     </h2>
     <p className="c-muted-2">
@@ -17,7 +19,7 @@ const LatestFeatures = () => (
       {latest.map(item => (
         <div
           className="pv4 bb b--muted-3 items-center"
-          key={slugify(item.description)}>
+          key={slug(item.description)}>
           <p className="t-heading-4 normal mv2">{item.title}</p>
           <p className="t-body c-on-base mb2">{item.description}</p>
         </div>
@@ -32,4 +34,4 @@ const LatestFeatures = () => (
   </section>
 )
 
-export default LatestFeatures
+export default injectIntl(LatestFeatures)

--- a/react/components/SideBar.tsx
+++ b/react/components/SideBar.tsx
@@ -56,7 +56,7 @@ function getArticles(
       text={chapter.title}
       link={chapter.path}
       hasArticles={chapter.articles.length > 0}
-      key={app}
+      key={chapter.title}
       depth={depth}>
       {getArticles(chapter.articles, app, version, depth + 1)}
     </SideBarItem>

--- a/react/utils/index.ts
+++ b/react/utils/index.ts
@@ -1,0 +1,9 @@
+import slugify from 'slugify'
+
+function slug(str: string) {
+  const replaced = (str && str.replace(/[*+~.()'"!:@&[\]]/g, '')) || ''
+  const slugified = slugify(replaced, { lower: true }) || ''
+  return slugified
+}
+
+export { slug }


### PR DESCRIPTION
#### What did you change? \*

Added a new `ArticleNav` component that renders a list of headings present in the current Markdown file (for the Home, this list is fixed) for navigation.

#### Why? \*

To enable the user to know at a glance what content can he find in the current open article and also facilitate navigation inside a certain article.

#### How to test it? \*

https://victorhmp--vtexpages.myvtex.com/docs/home

https://victorhmp--vtexpages.myvtex.com/docs/vtex.store-components@3.51.2+build1562608065

#### Types of changes \*

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical improvements
  <!--- * Required -->
