### PR TITLE
Recipe view page

### DIFF
--- a/pages/interfaces.json
+++ b/pages/interfaces.json
@@ -4,7 +4,7 @@
     "component": "Home"
   },
   "docs.app": {
-    "component": "AppDocs"
+    "component": "UnderConstruction"
   },
   "docs.construction": {
     "component": "UnderConstruction"

--- a/react/AppDocs.tsx
+++ b/react/AppDocs.tsx
@@ -3,7 +3,6 @@ import { Helmet } from 'vtex.render-runtime'
 
 import Footer from './components/Footer'
 import SideBar from './components/SideBar'
-import DocsRenderer from './components/DocsRenderer'
 import { EnhancedAppVersionProvider } from './components/AppVersionContext'
 import VersionSelector from './components/VersionSelector'
 import favicon from './images/favicon.png'
@@ -25,7 +24,6 @@ const AppDocs: FunctionComponent = () => {
             <div className="self-end ph9">
               <VersionSelector />
             </div>
-            <DocsRenderer />
           </div>
         </EnhancedAppVersionProvider>
       </main>

--- a/react/Recipe.tsx
+++ b/react/Recipe.tsx
@@ -1,0 +1,72 @@
+import React, { Fragment, FunctionComponent } from 'react'
+import { Query } from 'react-apollo'
+import { ApolloError } from 'apollo-client'
+import { Helmet, useRuntime } from 'vtex.render-runtime'
+
+import Footer from './components/Footer'
+import SideBar from './components/SideBar'
+import DocsRenderer from './components/DocsRenderer'
+import favicon from './images/favicon.png'
+import Skeleton from './components/Skeleton'
+import EmptyDocs from './components/EmptyDocs'
+
+import * as MarkdownFile from './graphql/getMarkdownFile.graphql'
+
+const Recipe: FunctionComponent = () => {
+  const {
+    route: { params },
+  } = useRuntime()
+
+  return (
+    <Fragment>
+      <Helmet>
+        <title>VTEX IO Docs</title>
+        <meta name="theme-color" content="#F71963" />
+        <link rel="icon" href={favicon} />
+      </Helmet>
+      <main className="w-100 bg-base flex">
+        <div className="w-25 min-h-100">
+          <SideBar />
+        </div>
+        <div className="pv10 w-80-l w-90 center flex flex-column">
+          <Query
+            query={MarkdownFile.default}
+            variables={{
+              appName: 'vtex.io-documentation@0.x',
+              fileName: `Recipes/${params.category}/${params.recipe}.md`,
+            }}>
+            {({
+              loading,
+              error,
+              data,
+            }: {
+              loading: boolean
+              error?: ApolloError
+              data: { getMarkdownFile: { markdown: string; meta: MetaData } }
+            }) => {
+              if (loading) return <Skeleton />
+              if (error) return <EmptyDocs />
+
+              const {
+                getMarkdownFile: { markdown, meta },
+              } = data
+
+              return <DocsRenderer markdown={markdown} meta={meta} />
+            }}
+          </Query>
+        </div>
+      </main>
+      <Footer />
+    </Fragment>
+  )
+}
+
+interface MetaData {
+  title: string
+  description: string
+  tags: string[]
+  version: string
+  git: string
+}
+
+export default Recipe

--- a/react/components/DocsRenderer.tsx
+++ b/react/components/DocsRenderer.tsx
@@ -1,15 +1,25 @@
 import React, { FunctionComponent } from 'react'
 import ReactMarkdown from 'react-markdown'
-import { Query } from 'react-apollo'
-import { ApolloError } from 'apollo-client'
 import { FormattedMessage } from 'react-intl'
 
-import Skeleton from './Skeleton'
-import EmptyDocs from './EmptyDocs'
 import { CustomRenderers } from './CustomTags'
-import { useAppNameAndFile } from '../hooks/useAppName'
 
-import * as MarkdownFile from '../graphql/getMarkdownFile.graphql'
+const DocsRenderer: FunctionComponent<Props> = ({ markdown, meta }) => {
+  return (
+    <article className="ph9 w-100 min-vh-100">
+      <ReactMarkdown
+        source={markdown}
+        escapeHtml={false}
+        renderers={CustomRenderers}
+      />
+      {meta.git && (
+        <a href={meta.git}>
+          <FormattedMessage id="docs/renderer-github" />
+        </a>
+      )}
+    </article>
+  )
+}
 
 interface MetaData {
   title: string
@@ -19,44 +29,9 @@ interface MetaData {
   git: string
 }
 
-const DocsRenderer: FunctionComponent = () => {
-  const { appName, fileName } = useAppNameAndFile()
-
-  return (
-    <Query query={MarkdownFile.default} variables={{ appName, fileName }}>
-      {({
-        loading,
-        error,
-        data,
-      }: {
-        loading: boolean
-        error?: ApolloError
-        data: { getMarkdownFile: { markdown: string; meta: MetaData } }
-      }) => {
-        if (loading) return <Skeleton />
-        if (error) return <EmptyDocs />
-
-        const { markdown, meta } = data.getMarkdownFile
-
-        if (markdown === '') return <EmptyDocs />
-
-        return (
-          <article className="ph9 w-100 min-vh-100">
-            <ReactMarkdown
-              source={markdown}
-              escapeHtml={false}
-              renderers={CustomRenderers}
-            />
-            {meta.git && (
-              <a href={meta.git}>
-                <FormattedMessage id="docs/renderer-github" />
-              </a>
-            )}
-          </article>
-        )
-      }}
-    </Query>
-  )
+interface Props {
+  markdown: string
+  meta: MetaData
 }
 
 export default DocsRenderer


### PR DESCRIPTION
#### What did you change? \*

Simplify the `DocsRenderer` component, so that it does not query for the Markdown it should render, it just receives it as props a markdown string which it should render and the metadata available for that file (written by the author in the front-matter section).

Add a new page that lives at `/docs/recipes/:category/:recipe` and makes the actual GraphQL query for a certain recipe.

#### Why? \*

The `DocsRenderer` component should not be responsible for querying its own markdown, as that involves different logic depending on the context in which it is being used. Now the component is much simpler and much more useful outside of the `AppDocs` component, an even in other apps.

The `Recipe` component had to be created as it has a different logic in regards to querying the data it is going to pass down to the `DocsRenderer` component.

#### How to test it? \*

https://victorhmp--vtexpages.myvtex.com/docs/recipes/style/customizeColors

### Related to / Depends on?

This PR is should be merged after (and contains commits from) PR #6.
Only the last 4 commits are unique.

#### Types of changes \*

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical improvements
  <!--- * Required -->
