### PR TITLE
Component Grid

### DIFF
--- a/pages/interfaces.json
+++ b/pages/interfaces.json
@@ -16,7 +16,7 @@
     "component": "Recipe"
   },
   "docs.components-list": {
-    "component": "UnderConstruction"
+    "component": "ComponentsGrid"
   },
   "docs.component": {
     "component": "UnderConstruction"

--- a/react/ComponentsGrid.tsx
+++ b/react/ComponentsGrid.tsx
@@ -1,0 +1,122 @@
+import React, { Fragment, FunctionComponent } from 'react'
+import { FormattedMessage, defineMessages } from 'react-intl'
+import { Helmet, NoSSR, withRuntimeContext } from 'vtex.render-runtime'
+import { compose, graphql } from 'react-apollo'
+import { branch, renderComponent } from 'recompose'
+
+import Footer from './components/Footer'
+import SideBar from './components/SideBar'
+import { slug } from './utils'
+
+import favicon from './images/favicon.png'
+
+import * as ComponentList from './graphql/componentsList.graphql'
+import ComponentGridItem from './components/ComponentGridItem'
+import EmptyDocs from './components/EmptyDocs'
+
+defineMessages({
+  general: {
+    id: 'docs/components/general',
+    defaultMessage: '',
+  },
+  navigation: {
+    id: 'docs/components/navigation',
+    defaultMessage: '',
+  },
+  product: {
+    id: 'docs/components/product-related',
+    defaultMessage: '',
+  },
+  search: {
+    id: 'docs/components/search-related',
+    defaultMessage: '',
+  },
+  all: {
+    id: 'docs/components/all',
+    defaultMessage: '',
+  },
+})
+
+const ComponentsGrid: FunctionComponent<any> = ({
+  ComponentsListQuery,
+  runtime,
+}) => {
+  const {
+    route: { params },
+  } = runtime
+
+  const componentsListForCategory =
+    ComponentsListQuery.componentsList[params.category]
+
+  return (
+    <Fragment>
+      <Helmet>
+        <title>VTEX IO Docs</title>
+        <meta name="theme-color" content="#F71963" />
+        <meta name="description" content="Documentation on VTEX IO" />
+        <link rel="icon" href={favicon} />
+      </Helmet>
+      <div className="flex min-h-100">
+        <NoSSR>
+          <div className="w-25 min-h-100">
+            <SideBar />
+          </div>
+        </NoSSR>
+        <div className="w-100">
+          <div className="flex">
+            <main className="flex w-90">
+              <div className="pv9 w-90 center">
+                <h1 className="t-heading-1 normal center mb6">
+                  <FormattedMessage id={`docs/components/${params.category}`} />
+                </h1>
+                <p className="small c-on-base center mb8">
+                  <FormattedMessage id="docs/lorem" />
+                </p>
+                <div className="flex flex-wrap">
+                  {componentsListForCategory &&
+                    componentsListForCategory.map((component: any) => (
+                      <div key={slug(component.title)} className="w-25">
+                        <ComponentGridItem
+                          title={component.title}
+                          description={component.description}
+                          link={`${params.category}/${
+                            component.appName
+                          }/${(component.file &&
+                            removeFileExtension(component.file)) ||
+                            ''}`}
+                        />
+                      </div>
+                    ))}
+                </div>
+              </div>
+            </main>
+          </div>
+          <Footer />
+        </div>
+      </div>
+    </Fragment>
+  )
+}
+
+function removeFileExtension(fileName: string) {
+  const MARKDOWN_EXTENSION = '.md'
+  return fileName.endsWith(MARKDOWN_EXTENSION)
+    ? fileName.substring(0, fileName.length - MARKDOWN_EXTENSION.length)
+    : fileName
+}
+
+export default compose(
+  withRuntimeContext,
+  graphql(ComponentList.default, {
+    name: 'ComponentsListQuery',
+    options: {
+      variables: {
+        appName: 'vtex.io-documentation@0.x',
+      },
+    },
+  }),
+  branch(
+    ({ ComponentsListQuery }: any) => !!ComponentsListQuery.error,
+    renderComponent(EmptyDocs)
+  )
+)(ComponentsGrid)

--- a/react/UnderConstruction.tsx
+++ b/react/UnderConstruction.tsx
@@ -16,15 +16,15 @@ const UnderConstruction: FunctionComponent = () => {
         <meta name="description" content="Documentation on VTEX IO" />
         <link rel="icon" href={favicon} />
       </Helmet>
-      <div className="flex min-h-100">
+      <div className="flex min-vh-100">
         <NoSSR>
           <div className="w-25 min-h-100">
             <SideBar />
           </div>
         </NoSSR>
-        <div className="w-100">
+        <div className="w-100 flex flex-column justify-between">
           <div className="flex">
-            <main className="w-100 pv10 min-vh-75 bg-base">
+            <main className="w-100 pv10 min-vh-75">
               <EmptyState title="Under Construction">
                 <p>This page is still being developed.</p>
                 <p>Come back in a bit and something awesome should be here!</p>

--- a/react/components/ComponentGridItem.tsx
+++ b/react/components/ComponentGridItem.tsx
@@ -16,12 +16,12 @@ const ComponentGridItem: FunctionComponent<Props> = ({
   link,
 }) => (
   <article className="flex flex-column items-between pv4 mh3 bt b--muted-1">
-    <p className="t-heading-4">{title}</p>
-    <p className="t-body c-on-base">{description}</p>
+    <h3 className="t-heading-4">{title}</h3>
+    <div className="t-body c-on-base mv5">{description}</div>
     <Link to={link} className="flex items-center no-underline link c-emphasis">
-      <p className="mr4">
+      <span className="mr4 mv5">
         <FormattedMessage id="docs/read-more" />
-      </p>
+      </span>
       <RightArrow />
     </Link>
   </article>

--- a/react/components/ComponentGridItem.tsx
+++ b/react/components/ComponentGridItem.tsx
@@ -1,0 +1,30 @@
+import React, { FunctionComponent } from 'react'
+import { FormattedMessage } from 'react-intl'
+import { Link } from 'vtex.render-runtime'
+
+import RightArrow from './icons/RightArrow'
+
+interface Props {
+  title: string
+  description: string
+  link: string
+}
+
+const ComponentGridItem: FunctionComponent<Props> = ({
+  title,
+  description,
+  link,
+}) => (
+  <article className="flex flex-column items-between pv4 mh3 bt b--muted-1">
+    <p className="t-heading-4">{title}</p>
+    <p className="t-body c-on-base">{description}</p>
+    <Link to={link} className="flex items-center no-underline link c-emphasis">
+      <p className="mr4">
+        <FormattedMessage id="docs/read-more" />
+      </p>
+      <RightArrow />
+    </Link>
+  </article>
+)
+
+export default ComponentGridItem

--- a/react/graphql/componentsList.graphql
+++ b/react/graphql/componentsList.graphql
@@ -1,0 +1,39 @@
+query componentsList($appName: String, $category: String) {
+  componentsList(appName: $appName) {
+    general {
+      appName
+      file
+      title
+      description
+      url
+    }
+    navigation {
+      appName
+      file
+      title
+      description
+      url
+    }
+    product {
+      appName
+      file
+      title
+      description
+      url
+    }
+    search {
+      appName
+      file
+      title
+      description
+      url
+    }
+    all {
+      appName
+      file
+      title
+      description
+      url
+    }
+  }
+}


### PR DESCRIPTION
#### What did you change? \*

Implement the component grid page that lives at `/docs/components/:category`. This page receives a dynamic list of components of a certain category from `vtex.io-documentation`. 

#### Why? \*

So that the user can see a list of components made by us, split into categories.

#### How to test it? \*

https://victorhmp--vtexpages.myvtex.com/docs/components/general

### Dependencies

This PR should be merged after PR #8 

#### Types of changes \*

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical improvements
  <!--- * Required -->
