### PR TITLE
Improve navigation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,5 @@
 # Docs UI
 
-This is the UI for VTEX IO documentation at https://vtex.io/docs
+This is the UI for VTEX IO documentation at https://vtex.io/docs.
+
+To contribute to the available content, please refer to [IO Documentation](https://github.com/vtex-apps/io-documentation).

--- a/pages/interfaces.json
+++ b/pages/interfaces.json
@@ -1,5 +1,10 @@
 {
-  "docs": {},
+  "docs-wrapper": {
+    "component": "PageLayoutContainer"
+  },
+  "docs": {
+    "around": ["docs-wrapper"]
+  },
   "docs.home": {
     "component": "Home"
   },

--- a/react/ComponentDocs.tsx
+++ b/react/ComponentDocs.tsx
@@ -1,13 +1,12 @@
 import React, { FC } from 'react'
 import { Query, compose, graphql } from 'react-apollo'
-import { branch, renderComponent, renderNothing } from 'recompose'
+import { branch, renderComponent } from 'recompose'
 import { ApolloError } from 'apollo-client'
 import { withRuntimeContext } from 'vtex.render-runtime'
 
 import DocsRenderer from './components/DocsRenderer'
 import Skeleton from './components/Skeleton'
 import EmptyDocs from './components/EmptyDocs'
-import PageLayoutContainer from './components/PageLayoutContainer'
 
 import * as MarkdownFile from './graphql/markdownFile.graphql'
 import * as AppMajors from './graphql/appMajors.graphql'
@@ -19,35 +18,33 @@ const ComponentDocs: FC<any> = ({ AppMajorsQuery, runtime }) => {
   )
 
   return (
-    <PageLayoutContainer>
-      <div className="pv9 w-90-l w-100 center flex flex-column">
-        <Query
-          query={MarkdownFile.default}
-          variables={{
-            appName,
-            fileName: `${fileName}.md`,
-          }}>
-          {({
-            loading,
-            error,
-            data,
-          }: {
-            loading: boolean
-            error?: ApolloError
-            data: { markdownFile: { markdown: string; meta: MetaData } }
-          }) => {
-            if (loading) return <Skeleton />
-            if (error) return <EmptyDocs />
+    <div className="pv9 w-90-l w-100 center flex flex-column">
+      <Query
+        query={MarkdownFile.default}
+        variables={{
+          appName,
+          fileName: `${fileName}.md`,
+        }}>
+        {({
+          loading,
+          error,
+          data,
+        }: {
+          loading: boolean
+          error?: ApolloError
+          data: { markdownFile: { markdown: string; meta: MetaData } }
+        }) => {
+          if (loading) return <Skeleton />
+          if (error || data.markdownFile.markdown === '') return <EmptyDocs />
 
-            const {
-              markdownFile: { markdown, meta },
-            } = data
+          const {
+            markdownFile: { markdown, meta },
+          } = data
 
-            return <DocsRenderer markdown={markdown} meta={meta} />
-          }}
-        </Query>
-      </div>
-    </PageLayoutContainer>
+          return <DocsRenderer markdown={markdown} meta={meta} />
+        }}
+      </Query>
+    </div>
   )
 }
 
@@ -82,7 +79,10 @@ export default compose(
       },
     }),
   }),
-  branch(({ AppMajorsQuery }: any) => AppMajorsQuery.loading, renderNothing),
+  branch(
+    ({ AppMajorsQuery }: any) => AppMajorsQuery.loading,
+    renderComponent(Skeleton)
+  ),
   branch(
     ({ AppMajorsQuery }: any) => !!AppMajorsQuery.error,
     renderComponent(EmptyDocs)

--- a/react/ComponentDocs.tsx
+++ b/react/ComponentDocs.tsx
@@ -18,7 +18,7 @@ const ComponentDocs: FC<any> = ({ AppMajorsQuery, runtime }) => {
   )
 
   return (
-    <div className="pv9 w-90-l w-100 center flex flex-column">
+    <div className="pv9 w-100 center flex flex-column">
       <Query
         query={MarkdownFile.default}
         variables={{

--- a/react/ComponentsGrid.tsx
+++ b/react/ComponentsGrid.tsx
@@ -44,7 +44,7 @@ const ComponentsGrid: FC<any> = ({ ComponentsListQuery }) => {
 
   return (
     <div className="pv9 w-90 center">
-      <h1 className="t-heading-1 normal center mb6">
+      <h1 className="t-heading-1 fw1 normal center mb6">
         <FormattedMessage id={`docs/components/${params.category}`} />
       </h1>
       <p className="small c-on-base center mb8">

--- a/react/ComponentsGrid.tsx
+++ b/react/ComponentsGrid.tsx
@@ -44,7 +44,7 @@ const ComponentsGrid: FC<any> = ({ ComponentsListQuery }) => {
 
   return (
     <div className="pv9 w-90 center">
-      <h1 className="t-heading-1  normal center mb6">
+      <h1 className="t-heading-1 center mb6">
         <FormattedMessage id={`docs/components/${params.category}`} />
       </h1>
       <p className="small c-on-base center mb8">

--- a/react/ComponentsGrid.tsx
+++ b/react/ComponentsGrid.tsx
@@ -1,14 +1,15 @@
 import React, { FC } from 'react'
 import { FormattedMessage, defineMessages } from 'react-intl'
 import { compose, graphql } from 'react-apollo'
-import { branch, renderComponent, renderNothing } from 'recompose'
+import { branch, renderComponent } from 'recompose'
+import { useRuntime } from 'vtex.render-runtime'
 
 import ComponentGridItem from './components/ComponentGridItem'
 import EmptyDocs from './components/EmptyDocs'
 import { slug } from './utils'
-import PageLayoutContainer from './components/PageLayoutContainer'
 
 import * as ComponentList from './graphql/componentsList.graphql'
+import Skeleton from './components/Skeleton'
 
 defineMessages({
   general: {
@@ -33,40 +34,38 @@ defineMessages({
   },
 })
 
-const ComponentsGrid: FC<any> = ({ ComponentsListQuery, runtime }) => {
+const ComponentsGrid: FC<any> = ({ ComponentsListQuery }) => {
   const {
     route: { params },
-  } = runtime
+  } = useRuntime()
 
   const componentsListForCategory =
     ComponentsListQuery.componentsList[params.category]
 
   return (
-    <PageLayoutContainer>
-      <div className="pv9 w-90 center">
-        <h1 className="t-heading-1 normal center mb6">
-          <FormattedMessage id={`docs/components/${params.category}`} />
-        </h1>
-        <p className="small c-on-base center mb8">
-          <FormattedMessage id="docs/lorem" />
-        </p>
-        <div className="flex flex-wrap">
-          {componentsListForCategory &&
-            componentsListForCategory.map((component: any) => (
-              <div key={slug(component.title)} className="w-50 w-25-l">
-                <ComponentGridItem
-                  title={component.title}
-                  description={component.description}
-                  link={`${params.category}/${
-                    component.appName
-                  }/${(component.file && removeFileExtension(component.file)) ||
-                    ''}`}
-                />
-              </div>
-            ))}
-        </div>
+    <div className="pv9 w-90 center">
+      <h1 className="t-heading-1 normal center mb6">
+        <FormattedMessage id={`docs/components/${params.category}`} />
+      </h1>
+      <p className="small c-on-base center mb8">
+        <FormattedMessage id="docs/lorem" />
+      </p>
+      <div className="flex flex-wrap">
+        {componentsListForCategory &&
+          componentsListForCategory.map((component: any) => (
+            <div key={slug(component.title)} className="w-50 w-25-l">
+              <ComponentGridItem
+                title={component.title}
+                description={component.description}
+                link={`${params.category}/${
+                  component.appName
+                }/${(component.file && removeFileExtension(component.file)) ||
+                  ''}`}
+              />
+            </div>
+          ))}
       </div>
-    </PageLayoutContainer>
+    </div>
   )
 }
 
@@ -89,7 +88,7 @@ export default compose(
   }),
   branch(
     ({ ComponentsListQuery }: any) => ComponentsListQuery.loading,
-    renderNothing
+    renderComponent(Skeleton)
   ),
   branch(
     ({ ComponentsListQuery }: any) => !!ComponentsListQuery.error,

--- a/react/ComponentsGrid.tsx
+++ b/react/ComponentsGrid.tsx
@@ -44,7 +44,7 @@ const ComponentsGrid: FC<any> = ({ ComponentsListQuery }) => {
 
   return (
     <div className="pv9 w-90 center">
-      <h1 className="t-heading-1 fw1 normal center mb6">
+      <h1 className="t-heading-1  normal center mb6">
         <FormattedMessage id={`docs/components/${params.category}`} />
       </h1>
       <p className="small c-on-base center mb8">

--- a/react/GettingStartedArticle.tsx
+++ b/react/GettingStartedArticle.tsx
@@ -23,7 +23,7 @@ const GettingStartedArticle: FC = ({ GettingStartedArticlesQuery }: any) => {
   )
 
   return (
-    <div className="pv9 w-90-l w-100 center flex flex-column">
+    <div className="pv9 w-100 center flex flex-column">
       <Query
         query={MarkdownFile.default}
         variables={{
@@ -52,7 +52,7 @@ const GettingStartedArticle: FC = ({ GettingStartedArticlesQuery }: any) => {
           return (
             <Fragment>
               <DocsRenderer markdown={markdown} meta={meta} />
-              <div className="flex justify-between">
+              <div className="flex w-80-l center justify-between">
                 {hasPrevArticle(currentArticle) && (
                   <Link
                     className="link no-underline t-body"

--- a/react/GettingStartedArticle.tsx
+++ b/react/GettingStartedArticle.tsx
@@ -1,13 +1,12 @@
 import React, { Fragment, FC } from 'react'
 import { Query, compose, graphql } from 'react-apollo'
 import { ApolloError } from 'apollo-client'
-import { branch, renderNothing } from 'recompose'
+import { branch, renderComponent } from 'recompose'
 import { useRuntime, withRuntimeContext, Link } from 'vtex.render-runtime'
 
 import DocsRenderer from './components/DocsRenderer'
 import Skeleton from './components/Skeleton'
 import EmptyDocs from './components/EmptyDocs'
-import PageLayoutContainer from './components/PageLayoutContainer'
 
 import * as MarkdownFile from './graphql/markdownFile.graphql'
 import * as GettingStartedArticles from './graphql/gettingStartedArticles.graphql'
@@ -24,58 +23,56 @@ const GettingStartedArticle: FC = ({ GettingStartedArticlesQuery }: any) => {
   )
 
   return (
-    <PageLayoutContainer>
-      <div className="pv9 w-90-l w-100 center flex flex-column">
-        <Query
-          query={MarkdownFile.default}
-          variables={{
-            appName: 'vtex.io-documentation@0.x',
-            fileName: `GettingStarted/${params.track}/${
-              articles[params.article]
-            }`,
-            locale: 'pt',
-          }}>
-          {({
-            loading,
-            error,
-            data,
-          }: {
-            loading: boolean
-            error?: ApolloError
-            data: { markdownFile: { markdown: string; meta: MetaData } }
-          }) => {
-            if (loading) return <Skeleton />
-            if (error) return <EmptyDocs />
+    <div className="pv9 w-90-l w-100 center flex flex-column">
+      <Query
+        query={MarkdownFile.default}
+        variables={{
+          appName: 'vtex.io-documentation@0.x',
+          fileName: `GettingStarted/${params.track}/${
+            articles[params.article]
+          }`,
+          locale: 'pt',
+        }}>
+        {({
+          loading,
+          error,
+          data,
+        }: {
+          loading: boolean
+          error?: ApolloError
+          data: { markdownFile: { markdown: string; meta: MetaData } }
+        }) => {
+          if (loading) return <Skeleton />
+          if (error) return <EmptyDocs />
 
-            const {
-              markdownFile: { markdown, meta },
-            } = data
+          const {
+            markdownFile: { markdown, meta },
+          } = data
 
-            return (
-              <Fragment>
-                <DocsRenderer markdown={markdown} meta={meta} />
-                <div className="flex justify-between">
-                  {hasPrevArticle(currentArticle) && (
-                    <Link
-                      className="link no-underline t-body"
-                      to={`${currentArticle - 1}`}>
-                      <span>Previous article</span>
-                    </Link>
-                  )}
-                  {hasNextArticle(articles, currentArticle) && (
-                    <Link
-                      className="link no-underline t-body"
-                      to={`${currentArticle + 1}`}>
-                      <span>Next article</span>
-                    </Link>
-                  )}
-                </div>
-              </Fragment>
-            )
-          }}
-        </Query>
-      </div>
-    </PageLayoutContainer>
+          return (
+            <Fragment>
+              <DocsRenderer markdown={markdown} meta={meta} />
+              <div className="flex justify-between">
+                {hasPrevArticle(currentArticle) && (
+                  <Link
+                    className="link no-underline t-body"
+                    to={`${currentArticle - 1}`}>
+                    <span>Previous article</span>
+                  </Link>
+                )}
+                {hasNextArticle(articles, currentArticle) && (
+                  <Link
+                    className="link no-underline t-body"
+                    to={`${currentArticle + 1}`}>
+                    <span>Next article</span>
+                  </Link>
+                )}
+              </div>
+            </Fragment>
+          )
+        }}
+      </Query>
+    </div>
   )
 }
 
@@ -116,6 +113,6 @@ export default compose(
   branch(
     ({ GettingStartedArticlesQuery }: any) =>
       GettingStartedArticlesQuery.loading,
-    renderNothing
+    renderComponent(Skeleton)
   )
 )(GettingStartedArticle)

--- a/react/Home.tsx
+++ b/react/Home.tsx
@@ -22,7 +22,7 @@ const Home: FC<InjectedIntlProps> = ({ intl }) => {
       <div className="pv9 w-100">
         <h1
           id={slug(intl.formatMessage({ id: 'docs/build' }))}
-          className="t-heading-1 fw1 w-90 w-80-ns center mb6">
+          className="t-heading-1  w-90 w-80-ns center mb6">
           <FormattedMessage id="docs/build" />
         </h1>
         <p className="small c-on-base w-90 w-80-ns center mb8">
@@ -36,7 +36,7 @@ const Home: FC<InjectedIntlProps> = ({ intl }) => {
                   <FormattedMessage id="docs/getting-started" />
                 </strong>
               </p>
-              <p className="t-heading-4 fw1 mv3 normal pv6 ttu">
+              <p className="t-heading-4  mv3 normal pv6 ttu">
                 <FormattedMessage id="docs/create-stores" />
               </p>
             </div>
@@ -47,7 +47,7 @@ const Home: FC<InjectedIntlProps> = ({ intl }) => {
               <div className="w-25-l w-10">
                 <Recipes />
               </div>
-              <p className="t-heading-4 fw1">
+              <p className="t-heading-4 ">
                 <FormattedMessage id="docs/recipes" />
               </p>
               <p className="c-muted-1">
@@ -66,7 +66,7 @@ const Home: FC<InjectedIntlProps> = ({ intl }) => {
               <div className="w-25-l w-10">
                 <Components />
               </div>
-              <p className="t-heading-4 fw1">
+              <p className="t-heading-4 ">
                 <FormattedMessage id="docs/our-components" />
               </p>
               <p className="c-muted-1">
@@ -85,7 +85,7 @@ const Home: FC<InjectedIntlProps> = ({ intl }) => {
               <div className="w-25-l w-10">
                 <Resources />
               </div>
-              <p className="t-heading-4 fw1">
+              <p className="t-heading-4 ">
                 <FormattedMessage id="docs/resources" />
               </p>
               <p className="c-muted-1">

--- a/react/Home.tsx
+++ b/react/Home.tsx
@@ -19,7 +19,7 @@ const Home: FC<InjectedIntlProps> = ({ intl }) => {
 
   return (
     <Fragment>
-      <div className="pv9">
+      <div className="pv9 w-100">
         <h1
           id={slug(intl.formatMessage({ id: 'docs/build' }))}
           className="t-heading-1 fw1 w-90 w-80-ns center mb6">

--- a/react/Home.tsx
+++ b/react/Home.tsx
@@ -1,11 +1,10 @@
-import React, { FC } from 'react'
+import React, { FC, Fragment } from 'react'
 import { FormattedMessage, injectIntl, InjectedIntlProps } from 'react-intl'
 
 import { slug } from './utils'
 import LatestFeatures from './components/LatestFeatures'
 import Community from './components/Community'
 import ArticleNav from './components/ArticleNav'
-import PageLayoutContainer from './components/PageLayoutContainer'
 import Recipes from './components/icons/Recipes'
 import Components from './components/icons/Components'
 import Resources from './components/icons/Resources'
@@ -19,7 +18,7 @@ const Home: FC<InjectedIntlProps> = ({ intl }) => {
   ]
 
   return (
-    <PageLayoutContainer>
+    <Fragment>
       <div className="pv9">
         <h1
           id={slug(intl.formatMessage({ id: 'docs/build' }))}
@@ -107,7 +106,7 @@ const Home: FC<InjectedIntlProps> = ({ intl }) => {
       <div className="pv9">
         <ArticleNav headings={homeHeadings} />
       </div>
-    </PageLayoutContainer>
+    </Fragment>
   )
 }
 

--- a/react/Home.tsx
+++ b/react/Home.tsx
@@ -22,7 +22,7 @@ const Home: FC<InjectedIntlProps> = ({ intl }) => {
       <div className="pv9">
         <h1
           id={slug(intl.formatMessage({ id: 'docs/build' }))}
-          className="t-heading-1 normal w-90 w-80-ns center mb6">
+          className="t-heading-1 fw1 w-90 w-80-ns center mb6">
           <FormattedMessage id="docs/build" />
         </h1>
         <p className="small c-on-base w-90 w-80-ns center mb8">
@@ -31,12 +31,12 @@ const Home: FC<InjectedIntlProps> = ({ intl }) => {
         <div className="w-90 w-80-ns center">
           <div className="flex w-100">
             <div className="w-25-l w-100 pt9 ph5 bg-muted-5 flex flex-column justify-end">
-              <p className="t-small ttu pv4">
-                <strong>
+              <p className="t-small pv4">
+                <strong className="ttu">
                   <FormattedMessage id="docs/getting-started" />
                 </strong>
               </p>
-              <p className="t-heading-4 mv3 normal pv6">
+              <p className="t-heading-4 fw1 mv3 normal pv6 ttu">
                 <FormattedMessage id="docs/create-stores" />
               </p>
             </div>
@@ -47,7 +47,7 @@ const Home: FC<InjectedIntlProps> = ({ intl }) => {
               <div className="w-25-l w-10">
                 <Recipes />
               </div>
-              <p className="t-heading-4">
+              <p className="t-heading-4 fw1">
                 <FormattedMessage id="docs/recipes" />
               </p>
               <p className="c-muted-1">
@@ -66,7 +66,7 @@ const Home: FC<InjectedIntlProps> = ({ intl }) => {
               <div className="w-25-l w-10">
                 <Components />
               </div>
-              <p className="t-heading-4">
+              <p className="t-heading-4 fw1">
                 <FormattedMessage id="docs/our-components" />
               </p>
               <p className="c-muted-1">
@@ -85,7 +85,7 @@ const Home: FC<InjectedIntlProps> = ({ intl }) => {
               <div className="w-25-l w-10">
                 <Resources />
               </div>
-              <p className="t-heading-4">
+              <p className="t-heading-4 fw1">
                 <FormattedMessage id="docs/resources" />
               </p>
               <p className="c-muted-1">

--- a/react/Home.tsx
+++ b/react/Home.tsx
@@ -36,7 +36,7 @@ const Home: FC<InjectedIntlProps> = ({ intl }) => {
                   <FormattedMessage id="docs/getting-started" />
                 </strong>
               </p>
-              <p className="t-heading-4  mv3 normal pv6 ttu">
+              <p className="t-heading-4 mv3 pv6 ttu">
                 <FormattedMessage id="docs/create-stores" />
               </p>
             </div>

--- a/react/PageLayoutContainer.tsx
+++ b/react/PageLayoutContainer.tsx
@@ -1,11 +1,11 @@
 import React, { Fragment, FC } from 'react'
 import { Helmet, NoSSR } from 'vtex.render-runtime'
 
-import Footer from './Footer'
+import Footer from './components/Footer'
 
-import favicon from '../images/favicon.png'
-import SideBar from './SideBar'
-import TopNav from './TopNav'
+import favicon from './images/favicon.png'
+import SideBar from './components/SideBar'
+import TopNav from './components/TopNav'
 
 const PageLayoutContainer: FC = ({ children }) => {
   return (
@@ -25,7 +25,7 @@ const PageLayoutContainer: FC = ({ children }) => {
         <div className="w-100">
           <div className="flex flex-column">
             <TopNav />
-            <main className="flex w-90-l">{children}</main>
+            <main className="flex w-90-l">{children || 'Loading'}</main>
           </div>
           <Footer />
         </div>

--- a/react/PageLayoutContainer.tsx
+++ b/react/PageLayoutContainer.tsx
@@ -25,7 +25,7 @@ const PageLayoutContainer: FC = ({ children }) => {
         <div className="w-100">
           <div className="flex flex-column">
             <TopNav />
-            <main className="flex w-90-l">{children || 'Loading'}</main>
+            <main className="flex w-90-l">{children}</main>
           </div>
           <Footer />
         </div>

--- a/react/Recipe.tsx
+++ b/react/Recipe.tsx
@@ -15,7 +15,7 @@ const Recipe: FC = () => {
   } = useRuntime()
 
   return (
-    <div className="pv9 w-90-l w-100 center flex flex-column">
+    <div className="pv9 w-100 center flex flex-column">
       <Query
         query={MarkdownFile.default}
         variables={{

--- a/react/Recipe.tsx
+++ b/react/Recipe.tsx
@@ -8,7 +8,6 @@ import Skeleton from './components/Skeleton'
 import EmptyDocs from './components/EmptyDocs'
 
 import * as MarkdownFile from './graphql/markdownFile.graphql'
-import PageLayoutContainer from './components/PageLayoutContainer'
 
 const Recipe: FC = () => {
   const {
@@ -16,36 +15,34 @@ const Recipe: FC = () => {
   } = useRuntime()
 
   return (
-    <PageLayoutContainer>
-      <div className="pv9 w-90-l w-100 center flex flex-column">
-        <Query
-          query={MarkdownFile.default}
-          variables={{
-            appName: 'vtex.io-documentation@0.x',
-            fileName: `Recipes/${params.category}/${params.recipe}.md`,
-            locale: 'en',
-          }}>
-          {({
-            loading,
-            error,
-            data,
-          }: {
-            loading: boolean
-            error?: ApolloError
-            data: { markdownFile: { markdown: string; meta: MetaData } }
-          }) => {
-            if (loading) return <Skeleton />
-            if (error) return <EmptyDocs />
+    <div className="pv9 w-90-l w-100 center flex flex-column">
+      <Query
+        query={MarkdownFile.default}
+        variables={{
+          appName: 'vtex.io-documentation@0.x',
+          fileName: `Recipes/${params.category}/${params.recipe}.md`,
+          locale: 'en',
+        }}>
+        {({
+          loading,
+          error,
+          data,
+        }: {
+          loading: boolean
+          error?: ApolloError
+          data: { markdownFile: { markdown: string; meta: MetaData } }
+        }) => {
+          if (loading) return <Skeleton />
+          if (error) return <EmptyDocs />
 
-            const {
-              markdownFile: { markdown, meta },
-            } = data
+          const {
+            markdownFile: { markdown, meta },
+          } = data
 
-            return <DocsRenderer markdown={markdown} meta={meta} />
-          }}
-        </Query>
-      </div>
-    </PageLayoutContainer>
+          return <DocsRenderer markdown={markdown} meta={meta} />
+        }}
+      </Query>
+    </div>
   )
 }
 

--- a/react/RecipesList.tsx
+++ b/react/RecipesList.tsx
@@ -45,7 +45,7 @@ const RecipesList: FC<any> = ({ RecipeListQuery, runtime }) => {
 
   return (
     <div className="pv9">
-      <h1 className="t-heading-1 normal w-90 w-80-ns center mb6">
+      <h1 className="t-heading-1 normal fw1 w-90 w-80-ns center mb6">
         <FormattedMessage id={`docs/recipes/${params.category}`} />
       </h1>
       <p className="small c-on-base w-90 w-80-ns center mb8">

--- a/react/RecipesList.tsx
+++ b/react/RecipesList.tsx
@@ -45,7 +45,7 @@ const RecipesList: FC<any> = ({ RecipeListQuery, runtime }) => {
 
   return (
     <div className="pv9">
-      <h1 className="t-heading-1 normal fw1 w-90 w-80-ns center mb6">
+      <h1 className="t-heading-1 normal  w-90 w-80-ns center mb6">
         <FormattedMessage id={`docs/recipes/${params.category}`} />
       </h1>
       <p className="small c-on-base w-90 w-80-ns center mb8">

--- a/react/RecipesList.tsx
+++ b/react/RecipesList.tsx
@@ -45,7 +45,7 @@ const RecipesList: FC<any> = ({ RecipeListQuery, runtime }) => {
 
   return (
     <div className="pv9">
-      <h1 className="t-heading-1 normal  w-90 w-80-ns center mb6">
+      <h1 className="t-heading-1 w-90 w-80-ns center mb6">
         <FormattedMessage id={`docs/recipes/${params.category}`} />
       </h1>
       <p className="small c-on-base w-90 w-80-ns center mb8">

--- a/react/RecipesList.tsx
+++ b/react/RecipesList.tsx
@@ -2,14 +2,14 @@ import React, { FC } from 'react'
 import { FormattedMessage, defineMessages } from 'react-intl'
 import { withRuntimeContext } from 'vtex.render-runtime'
 import { compose, graphql } from 'react-apollo'
-import { branch, renderComponent, renderNothing } from 'recompose'
+import { branch, renderComponent } from 'recompose'
 
 import RecipeListItem from './components/RecipeListItem'
 import EmptyDocs from './components/EmptyAppDocs'
 import { slug } from './utils'
 
 import * as RecipeList from './graphql/recipesList.graphql'
-import PageLayoutContainer from './components/PageLayoutContainer'
+import Skeleton from './components/Skeleton'
 
 defineMessages({
   style: {
@@ -44,26 +44,24 @@ const RecipesList: FC<any> = ({ RecipeListQuery, runtime }) => {
   } = runtime
 
   return (
-    <PageLayoutContainer>
-      <div className="pv9">
-        <h1 className="t-heading-1 normal w-90 w-80-ns center mb6">
-          <FormattedMessage id={`docs/recipes/${params.category}`} />
-        </h1>
-        <p className="small c-on-base w-90 w-80-ns center mb8">
-          <FormattedMessage id="docs/lorem" />
-        </p>
-        <div className="w-90 w-80-ns center">
-          {RecipeListQuery.recipeList.map((recipe: Recipe) => (
-            <RecipeListItem
-              key={slug(recipe.description)}
-              title={recipe.title}
-              description={recipe.description}
-              link={getShortRecipePath(recipe.path)}
-            />
-          ))}
-        </div>
+    <div className="pv9">
+      <h1 className="t-heading-1 normal w-90 w-80-ns center mb6">
+        <FormattedMessage id={`docs/recipes/${params.category}`} />
+      </h1>
+      <p className="small c-on-base w-90 w-80-ns center mb8">
+        <FormattedMessage id="docs/lorem" />
+      </p>
+      <div className="w-90 w-80-ns center">
+        {RecipeListQuery.recipeList.map((recipe: Recipe) => (
+          <RecipeListItem
+            key={slug(recipe.description)}
+            title={recipe.title}
+            description={recipe.description}
+            link={getShortRecipePath(recipe.path)}
+          />
+        ))}
       </div>
-    </PageLayoutContainer>
+    </div>
   )
 }
 
@@ -102,7 +100,10 @@ export default compose(
       }
     },
   }),
-  branch(({ RecipeListQuery }: any) => RecipeListQuery.loading, renderNothing),
+  branch(
+    ({ RecipeListQuery }: any) => RecipeListQuery.loading,
+    renderComponent(Skeleton)
+  ),
   branch(
     ({ RecipeListQuery }: any) => !!RecipeListQuery.error,
     renderComponent(EmptyDocs)

--- a/react/Resource.tsx
+++ b/react/Resource.tsx
@@ -15,7 +15,7 @@ const Resource: FC = () => {
   } = useRuntime()
 
   return (
-    <div className="pv9 w-90-l w-100 center flex flex-column">
+    <div className="pv9 w-100 center flex flex-column">
       <Query
         query={MarkdownFile.default}
         variables={{

--- a/react/Resource.tsx
+++ b/react/Resource.tsx
@@ -8,7 +8,6 @@ import Skeleton from './components/Skeleton'
 import EmptyDocs from './components/EmptyDocs'
 
 import * as MarkdownFile from './graphql/markdownFile.graphql'
-import PageLayoutContainer from './components/PageLayoutContainer'
 
 const Resource: FC = () => {
   const {
@@ -16,36 +15,34 @@ const Resource: FC = () => {
   } = useRuntime()
 
   return (
-    <PageLayoutContainer>
-      <div className="pv9 w-90-l w-100 center flex flex-column">
-        <Query
-          query={MarkdownFile.default}
-          variables={{
-            appName: 'vtex.io-documentation@0.x',
-            fileName: `Resources/${params.resource}.md`,
-            locale: 'en',
-          }}>
-          {({
-            loading,
-            error,
-            data,
-          }: {
-            loading: boolean
-            error?: ApolloError
-            data: { markdownFile: { markdown: string; meta: MetaData } }
-          }) => {
-            if (loading) return <Skeleton />
-            if (error) return <EmptyDocs />
+    <div className="pv9 w-90-l w-100 center flex flex-column">
+      <Query
+        query={MarkdownFile.default}
+        variables={{
+          appName: 'vtex.io-documentation@0.x',
+          fileName: `Resources/${params.resource}.md`,
+          locale: 'en',
+        }}>
+        {({
+          loading,
+          error,
+          data,
+        }: {
+          loading: boolean
+          error?: ApolloError
+          data: { markdownFile: { markdown: string; meta: MetaData } }
+        }) => {
+          if (loading) return <Skeleton />
+          if (error) return <EmptyDocs />
 
-            const {
-              markdownFile: { markdown, meta },
-            } = data
+          const {
+            markdownFile: { markdown, meta },
+          } = data
 
-            return <DocsRenderer markdown={markdown} meta={meta} />
-          }}
-        </Query>
-      </div>
-    </PageLayoutContainer>
+          return <DocsRenderer markdown={markdown} meta={meta} />
+        }}
+      </Query>
+    </div>
   )
 }
 

--- a/react/ResourcesList.tsx
+++ b/react/ResourcesList.tsx
@@ -1,39 +1,35 @@
 import React, { FC } from 'react'
 import { FormattedMessage } from 'react-intl'
 import { compose, graphql } from 'react-apollo'
-import { branch, renderComponent, renderNothing } from 'recompose'
+import { branch, renderComponent } from 'recompose'
 
 import RecipeListItem from './components/RecipeListItem'
 import EmptyDocs from './components/EmptyAppDocs'
 import { slug } from './utils'
 
 import * as ResourceList from './graphql/resourcesList.graphql'
-import PageLayoutContainer from './components/PageLayoutContainer'
+import Skeleton from './components/Skeleton'
 
-const ResourcesList: FC<InnerProps> = ({ ResourcesListQueryData }) => {
-  return (
-    <PageLayoutContainer>
-      <div className="pv9">
-        <h1 className="t-heading-1 normal w-90 w-80-ns center mb6">
-          <FormattedMessage id="docs/resources" />
-        </h1>
-        <p className="small c-on-base w-90 w-80-ns center mb8">
-          <FormattedMessage id="docs/lorem" />
-        </p>
-        <div className="w-90 w-80-ns center">
-          {ResourcesListQueryData.resourcesList.map((resource: Resource) => (
-            <RecipeListItem
-              key={slug(resource.description)}
-              title={resource.title}
-              description={resource.description}
-              link={`resources/${getShortResourcePath(resource.path)}`}
-            />
-          ))}
-        </div>
-      </div>
-    </PageLayoutContainer>
-  )
-}
+const ResourcesList: FC<InnerProps> = ({ ResourcesListQueryData }) => (
+  <div className="pv9">
+    <h1 className="t-heading-1 normal w-90 w-80-ns center mb6">
+      <FormattedMessage id="docs/resources" />
+    </h1>
+    <p className="small c-on-base w-90 w-80-ns center mb8">
+      <FormattedMessage id="docs/lorem" />
+    </p>
+    <div className="w-90 w-80-ns center">
+      {ResourcesListQueryData.resourcesList.map((resource: Resource) => (
+        <RecipeListItem
+          key={slug(resource.description)}
+          title={resource.title}
+          description={resource.description}
+          link={`resources/${getShortResourcePath(resource.path)}`}
+        />
+      ))}
+    </div>
+  </div>
+)
 
 function getShortResourcePath(path: string) {
   // the path will always be something like: dist/vtex.docs-graphql/<locale>/Resources/<fileName>.md
@@ -74,7 +70,7 @@ export default compose(
   }),
   branch(
     ({ ResourcesListQueryData }: InnerProps) => ResourcesListQueryData.loading,
-    renderNothing
+    renderComponent(Skeleton)
   ),
   branch(
     ({ ResourcesListQueryData }: InnerProps) =>

--- a/react/ResourcesList.tsx
+++ b/react/ResourcesList.tsx
@@ -12,7 +12,7 @@ import Skeleton from './components/Skeleton'
 
 const ResourcesList: FC<InnerProps> = ({ ResourcesListQueryData }) => (
   <div className="pv9">
-    <h1 className="t-heading-1 fw1 normal w-90 w-80-ns center mb6">
+    <h1 className="t-heading-1  normal w-90 w-80-ns center mb6">
       <FormattedMessage id="docs/resources" />
     </h1>
     <p className="small c-on-base w-90 w-80-ns center mb8">

--- a/react/ResourcesList.tsx
+++ b/react/ResourcesList.tsx
@@ -12,7 +12,7 @@ import Skeleton from './components/Skeleton'
 
 const ResourcesList: FC<InnerProps> = ({ ResourcesListQueryData }) => (
   <div className="pv9">
-    <h1 className="t-heading-1  normal w-90 w-80-ns center mb6">
+    <h1 className="t-heading-1 w-90 w-80-ns center mb6">
       <FormattedMessage id="docs/resources" />
     </h1>
     <p className="small c-on-base w-90 w-80-ns center mb8">

--- a/react/ResourcesList.tsx
+++ b/react/ResourcesList.tsx
@@ -12,7 +12,7 @@ import Skeleton from './components/Skeleton'
 
 const ResourcesList: FC<InnerProps> = ({ ResourcesListQueryData }) => (
   <div className="pv9">
-    <h1 className="t-heading-1 normal w-90 w-80-ns center mb6">
+    <h1 className="t-heading-1 fw1 normal w-90 w-80-ns center mb6">
       <FormattedMessage id="docs/resources" />
     </h1>
     <p className="small c-on-base w-90 w-80-ns center mb8">

--- a/react/UnderConstruction.tsx
+++ b/react/UnderConstruction.tsx
@@ -1,19 +1,13 @@
 import React, { FC } from 'react'
 import { EmptyState } from 'vtex.styleguide'
 
-import PageLayoutContainer from './components/PageLayoutContainer'
-
-const UnderConstruction: FC = () => {
-  return (
-    <PageLayoutContainer>
-      <div className="min-vh-100 w-100 flex justify-center items-center">
-        <EmptyState title="Under Construction">
-          <p>This page is still being developed.</p>
-          <p>Come back in a bit and something awesome should be here!</p>
-        </EmptyState>
-      </div>
-    </PageLayoutContainer>
-  )
-}
+const UnderConstruction: FC = () => (
+  <div className="min-vh-100 w-100 flex justify-center items-center">
+    <EmptyState title="Under Construction">
+      <p>This page is still being developed.</p>
+      <p>Come back in a bit and something awesome should be here!</p>
+    </EmptyState>
+  </div>
+)
 
 export default UnderConstruction

--- a/react/components/Community.tsx
+++ b/react/components/Community.tsx
@@ -8,7 +8,7 @@ const Community: FC<InjectedIntlProps> = ({ intl }) => (
   <section className="mv9">
     <h2
       id={slug(intl.formatMessage({ id: 'docs/community-help' }))}
-      className="t-heading-2 normal">
+      className="t-heading-2 normal fw1">
       <FormattedMessage id="docs/community-help" />
     </h2>
     <a
@@ -19,7 +19,7 @@ const Community: FC<InjectedIntlProps> = ({ intl }) => (
           <CommunityIcon />
         </div>
         <div className="ml6">
-          <h4 className="t-heading-4 c-on-base">
+          <h4 className="t-heading-4 fw1 c-on-base">
             <FormattedMessage id="docs/community-join" />
           </h4>
           <p className="t-body c-on-base">

--- a/react/components/Community.tsx
+++ b/react/components/Community.tsx
@@ -8,7 +8,7 @@ const Community: FC<InjectedIntlProps> = ({ intl }) => (
   <section className="mv9">
     <h2
       id={slug(intl.formatMessage({ id: 'docs/community-help' }))}
-      className="t-heading-2 normal fw1">
+      className="t-heading-2 normal">
       <FormattedMessage id="docs/community-help" />
     </h2>
     <a
@@ -19,7 +19,7 @@ const Community: FC<InjectedIntlProps> = ({ intl }) => (
           <CommunityIcon />
         </div>
         <div className="ml6">
-          <h4 className="t-heading-4 fw1 c-on-base">
+          <h4 className="t-heading-4  c-on-base">
             <FormattedMessage id="docs/community-join" />
           </h4>
           <p className="t-body c-on-base">

--- a/react/components/Community.tsx
+++ b/react/components/Community.tsx
@@ -8,7 +8,7 @@ const Community: FC<InjectedIntlProps> = ({ intl }) => (
   <section className="mv9">
     <h2
       id={slug(intl.formatMessage({ id: 'docs/community-help' }))}
-      className="t-heading-2 normal">
+      className="t-heading-2">
       <FormattedMessage id="docs/community-help" />
     </h2>
     <a

--- a/react/components/ComponentGridItem.tsx
+++ b/react/components/ComponentGridItem.tsx
@@ -12,7 +12,7 @@ interface Props {
 
 const ComponentGridItem: FC<Props> = ({ title, description, link }) => (
   <article className="flex flex-column items-between pv4 mh3-l bt b--muted-1">
-    <h3 className="t-heading-4">{title}</h3>
+    <h3 className="t-heading-4 fw1">{title}</h3>
     <div className="t-body c-on-base mv5">{description}</div>
     <Link to={link} className="flex items-center no-underline link c-emphasis">
       <span className="mr4 mv5">

--- a/react/components/ComponentGridItem.tsx
+++ b/react/components/ComponentGridItem.tsx
@@ -12,7 +12,7 @@ interface Props {
 
 const ComponentGridItem: FC<Props> = ({ title, description, link }) => (
   <article className="flex flex-column items-between pv4 mh3-l bt b--muted-1">
-    <h3 className="t-heading-4 fw1">{title}</h3>
+    <h3 className="t-heading-4">{title}</h3>
     <div className="t-body c-on-base mv5">{description}</div>
     <Link to={link} className="flex items-center no-underline link c-emphasis">
       <span className="mr4 mv5">

--- a/react/components/CustomTags.tsx
+++ b/react/components/CustomTags.tsx
@@ -29,7 +29,7 @@ export const CustomRenderers = {
 
     return (
       <div className="flex">
-        <div className="flex flex-column w-70-l">{children}</div>
+        <div className="flex flex-column w-80-l">{children}</div>
         {TOCLines.length > 0 && <ArticleNav headings={TOCLines} />}
       </div>
     )

--- a/react/components/CustomTags.tsx
+++ b/react/components/CustomTags.tsx
@@ -55,28 +55,28 @@ export const CustomRenderers = {
     switch (props.level) {
       case 1:
         return (
-          <h1 id={hashId} className="t-heading-1 c-on-base mt7 mb7">
+          <h1 id={hashId} className="t-heading-1 fw1 c-on-base mt7 mb7">
             {props.children}
           </h1>
         )
 
       case 2:
         return (
-          <h2 id={hashId} className="t-heading-2 mt9 mb5 c-on-base">
+          <h2 id={hashId} className="t-heading-2 fw1 mt9 mb5 c-on-base">
             {props.children}
           </h2>
         )
 
       case 3:
         return (
-          <h3 id={hashId} className="t-heading-3 mt7 c-on-base">
+          <h3 id={hashId} className="t-heading-3 fw1 mt7 c-on-base">
             {props.children}
           </h3>
         )
 
       case 4:
         return (
-          <h4 id={hashId} className="t-heading-4 mt7 c-on-base">
+          <h4 id={hashId} className="t-heading-4 fw1 mt7 c-on-base">
             {props.children}
           </h4>
         )

--- a/react/components/CustomTags.tsx
+++ b/react/components/CustomTags.tsx
@@ -55,28 +55,28 @@ export const CustomRenderers = {
     switch (props.level) {
       case 1:
         return (
-          <h1 id={hashId} className="t-heading-1 fw1 c-on-base mt7 mb7">
+          <h1 id={hashId} className="t-heading-1 c-on-base mt7 mb7">
             {props.children}
           </h1>
         )
 
       case 2:
         return (
-          <h2 id={hashId} className="t-heading-2 fw1 mt9 mb5 c-on-base">
+          <h2 id={hashId} className="t-heading-2 mt9 mb5 c-on-base">
             {props.children}
           </h2>
         )
 
       case 3:
         return (
-          <h3 id={hashId} className="t-heading-3 fw1 mt7 c-on-base">
+          <h3 id={hashId} className="t-heading-3 mt7 c-on-base">
             {props.children}
           </h3>
         )
 
       case 4:
         return (
-          <h4 id={hashId} className="t-heading-4 fw1 mt7 c-on-base">
+          <h4 id={hashId} className="t-heading-4 mt7 c-on-base">
             {props.children}
           </h4>
         )

--- a/react/components/LatestFeatures.tsx
+++ b/react/components/LatestFeatures.tsx
@@ -9,7 +9,7 @@ const LatestFeatures: FC<InjectedIntlProps> = ({ intl }) => (
   <section className="mv9">
     <h2
       id={slug(intl.formatMessage({ id: 'docs/latest-features' }))}
-      className="t-heading-2 normal fw1 mv4">
+      className="t-heading-2 normal  mv4">
       <FormattedMessage id="docs/latest-features" />
     </h2>
     <p className="c-on-base">
@@ -20,7 +20,7 @@ const LatestFeatures: FC<InjectedIntlProps> = ({ intl }) => (
         <div
           className="pv4 bb b--muted-3 items-center"
           key={slug(item.description)}>
-          <p className="t-heading-4 fw1 normal mv2">{item.title}</p>
+          <p className="t-heading-4 normal mv2">{item.title}</p>
           <p className="t-body c-on-base mb2">{item.description}</p>
         </div>
       ))}

--- a/react/components/LatestFeatures.tsx
+++ b/react/components/LatestFeatures.tsx
@@ -9,7 +9,7 @@ const LatestFeatures: FC<InjectedIntlProps> = ({ intl }) => (
   <section className="mv9">
     <h2
       id={slug(intl.formatMessage({ id: 'docs/latest-features' }))}
-      className="t-heading-2 normal  mv4">
+      className="t-heading-2 mv4">
       <FormattedMessage id="docs/latest-features" />
     </h2>
     <p className="c-on-base">
@@ -20,7 +20,7 @@ const LatestFeatures: FC<InjectedIntlProps> = ({ intl }) => (
         <div
           className="pv4 bb b--muted-3 items-center"
           key={slug(item.description)}>
-          <p className="t-heading-4 normal mv2">{item.title}</p>
+          <p className="t-heading-4  mv2">{item.title}</p>
           <p className="t-body c-on-base mb2">{item.description}</p>
         </div>
       ))}

--- a/react/components/LatestFeatures.tsx
+++ b/react/components/LatestFeatures.tsx
@@ -9,7 +9,7 @@ const LatestFeatures: FC<InjectedIntlProps> = ({ intl }) => (
   <section className="mv9">
     <h2
       id={slug(intl.formatMessage({ id: 'docs/latest-features' }))}
-      className="t-heading-2 normal mv4">
+      className="t-heading-2 normal fw1 mv4">
       <FormattedMessage id="docs/latest-features" />
     </h2>
     <p className="c-on-base">
@@ -20,7 +20,7 @@ const LatestFeatures: FC<InjectedIntlProps> = ({ intl }) => (
         <div
           className="pv4 bb b--muted-3 items-center"
           key={slug(item.description)}>
-          <p className="t-heading-4 normal mv2">{item.title}</p>
+          <p className="t-heading-4 fw1 normal mv2">{item.title}</p>
           <p className="t-body c-on-base mb2">{item.description}</p>
         </div>
       ))}

--- a/react/components/RecipeListItem.tsx
+++ b/react/components/RecipeListItem.tsx
@@ -13,7 +13,7 @@ interface Props {
 
 const RecipeListItem: FC<Props> = ({ title, description, link }) => (
   <article className="flex flex-column justify-center mv4 no-underline">
-    <h2 className="t-heading-2 normal">{title}</h2>
+    <h2 className="t-heading-2">{title}</h2>
     <p className="t-body c-on-base">{description}</p>
     <Link
       to={link}

--- a/react/components/RecipeListItem.tsx
+++ b/react/components/RecipeListItem.tsx
@@ -13,7 +13,7 @@ interface Props {
 
 const RecipeListItem: FC<Props> = ({ title, description, link }) => (
   <article className="flex flex-column justify-center mv4 no-underline">
-    <h2 className="t-heading-2 fw1 normal">{title}</h2>
+    <h2 className="t-heading-2 normal">{title}</h2>
     <p className="t-body c-on-base">{description}</p>
     <Link
       to={link}

--- a/react/components/RecipeListItem.tsx
+++ b/react/components/RecipeListItem.tsx
@@ -13,7 +13,7 @@ interface Props {
 
 const RecipeListItem: FC<Props> = ({ title, description, link }) => (
   <article className="flex flex-column justify-center mv4 no-underline">
-    <h2 className="t-heading-2 normal">{title}</h2>
+    <h2 className="t-heading-2 fw1 normal">{title}</h2>
     <p className="t-body c-on-base">{description}</p>
     <Link
       to={link}

--- a/react/components/SideBar.tsx
+++ b/react/components/SideBar.tsx
@@ -1,20 +1,21 @@
 import React, { ReactElement, FC } from 'react'
 import { Query } from 'react-apollo'
 import { ApolloError } from 'apollo-client'
+import { Drawer } from 'vtex.store-drawer'
+import { Link } from 'vtex.render-runtime'
 
 import SideBarItem from './SideBarItem'
 import Skeleton from './Skeleton'
 import EmptySummary from './EmptySummary'
 import { useAppNameAndFile } from '../hooks/useAppName'
-import { Drawer } from 'vtex.store-drawer'
-import { Link } from 'vtex.render-runtime'
+import { formatLink } from '../utils'
 
 import VTEXBlack from './icons/VTEXBlack'
 import * as Summary from '../graphql/appSummary.graphql'
 
 interface Chapter {
   title: string
-  path: string
+  path?: string
   articles: [] | Chapter[]
 }
 
@@ -75,9 +76,8 @@ function getArticles(
     <div className={`list ${depth > 0 ? 'pl0-l pr2-l pt5 pb5' : 'pa7-l'}`}>
       {chapterList.map((chapter: Chapter) => (
         <SideBarItem
-          appName={app}
           text={chapter.title}
-          link={chapter.path && removeFileExtension(chapter.path)}
+          link={chapter.path && formatLink(chapter.path)}
           hasArticles={chapter.articles.length > 0}
           key={chapter.title}
           depth={depth}>
@@ -86,13 +86,6 @@ function getArticles(
       ))}
     </div>
   )
-}
-
-function removeFileExtension(fileName: string) {
-  const MARKDOWN_EXTENSION = '.md'
-  return fileName.endsWith(MARKDOWN_EXTENSION)
-    ? fileName.substring(0, fileName.length - MARKDOWN_EXTENSION.length)
-    : fileName
 }
 
 export default SideBar

--- a/react/components/SideBarItem.tsx
+++ b/react/components/SideBarItem.tsx
@@ -15,16 +15,12 @@ interface Props {
 const SideBarItem: FC<Props> = ({
   text,
   link,
-  appName,
   depth,
   hasArticles,
   children,
 }) => {
   const activeUrl = useRuntime().route.path
-  const isIODocs = appName && appName.split('@')[0] === 'vtex.io-documentation'
-  const linkUrl =
-    link && `/docs${!isIODocs && appName ? `/${appName}` : ''}/${link}`
-  const isActive = linkUrl === activeUrl
+  const isActive = link === activeUrl
   const activeCategory = activeUrl.split('/')[2]
   const activeSubCategory = activeUrl.split('/')[3]
   const hasActiveChildren =
@@ -47,12 +43,12 @@ const SideBarItem: FC<Props> = ({
         onKeyPress={() => setOpen(!open)}
         role="menuitem"
         tabIndex={-1}>
-        {linkUrl ? (
-          <Link
-            to={linkUrl}
+        {link ? (
+          <a
+            href={link}
             className={`no-underline ${isActive ? 'c-emphasis' : 'c-on-base'}`}>
             {depth === 0 ? <ZeroDepthItem /> : <NormalItem />}
-          </Link>
+          </a>
         ) : depth === 0 ? (
           <ZeroDepthItem />
         ) : (

--- a/react/components/SideBarItem.tsx
+++ b/react/components/SideBarItem.tsx
@@ -44,11 +44,11 @@ const SideBarItem: FC<Props> = ({
         role="menuitem"
         tabIndex={-1}>
         {link ? (
-          <a
+          <Link
             href={link}
             className={`no-underline ${isActive ? 'c-emphasis' : 'c-on-base'}`}>
             {depth === 0 ? <ZeroDepthItem /> : <NormalItem />}
-          </a>
+          </Link>
         ) : depth === 0 ? (
           <ZeroDepthItem />
         ) : (

--- a/react/utils/index.ts
+++ b/react/utils/index.ts
@@ -7,4 +7,24 @@ function slug(str: string) {
   return slugified
 }
 
-export { slug }
+function formatLink(path: string) {
+  const isExternalLink = !!path && path.match(/((http(s)?):\/)|(www.)/)
+  // There is an issue during the parsing of Summary.md at `docs-graphql`
+  const PROTOCOL_PREFIX = 'https:/'
+  const linkUrl = isExternalLink
+    ? `https://${path.substring(PROTOCOL_PREFIX.length)}`
+    : `/docs/${removeFileExtension(path)}`
+
+  return linkUrl
+}
+
+function removeFileExtension(fileName: string) {
+  const MARKDOWN_EXTENSION = '.md'
+  const hasExtension = fileName.endsWith(MARKDOWN_EXTENSION)
+
+  return !hasExtension
+    ? fileName
+    : fileName.substring(0, fileName.length - MARKDOWN_EXTENSION.length)
+}
+
+export { slug, formatLink, removeFileExtension }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4729,7 +4729,7 @@ read-pkg@^3.0.0:
 readable-stream@^2.0.1, readable-stream@^2.0.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
-  integrity sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
+  integrity sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2y+J/YA9dUrAC39ITejlZWhVIwawkKw==
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.3"

--- a/styles/configs/style.json
+++ b/styles/configs/style.json
@@ -266,42 +266,42 @@
     "styles": {
       "heading-1": {
         "fontFamily": "Fabriga, -apple-system, BlinkMacSystemFont, avenir next, avenir, helvetica neue, helvetica, ubuntu, roboto, noto, segoe ui, arial, sans-serif",
-        "fontWeight": "700",
+        "fontWeight": "100",
         "fontSize": "3rem",
         "textTransform": "initial",
         "letterSpacing": "0"
       },
       "heading-2": {
         "fontFamily": "Fabriga, -apple-system, BlinkMacSystemFont, avenir next, avenir, helvetica neue, helvetica, ubuntu, roboto, noto, segoe ui, arial, sans-serif",
-        "fontWeight": "700",
+        "fontWeight": "100",
         "fontSize": "2.25rem",
         "textTransform": "initial",
         "letterSpacing": "0"
       },
       "heading-3": {
         "fontFamily": "Fabriga, -apple-system, BlinkMacSystemFont, avenir next, avenir, helvetica neue, helvetica, ubuntu, roboto, noto, segoe ui, arial, sans-serif",
-        "fontWeight": "700",
+        "fontWeight": "100",
         "fontSize": "1.75rem",
         "textTransform": "initial",
         "letterSpacing": "0"
       },
       "heading-4": {
         "fontFamily": "Fabriga, -apple-system, BlinkMacSystemFont, avenir next, avenir, helvetica neue, helvetica, ubuntu, roboto, noto, segoe ui, arial, sans-serif",
-        "fontWeight": "normal",
+        "fontWeight": "100",
         "fontSize": "1.5rem",
         "textTransform": "initial",
         "letterSpacing": "0"
       },
       "heading-5": {
         "fontFamily": "Fabriga, -apple-system, BlinkMacSystemFont, avenir next, avenir, helvetica neue, helvetica, ubuntu, roboto, noto, segoe ui, arial, sans-serif",
-        "fontWeight": "normal",
+        "fontWeight": "100",
         "fontSize": "1.25rem",
         "textTransform": "initial",
         "letterSpacing": "0"
       },
       "heading-6": {
         "fontFamily": "Fabriga, -apple-system, BlinkMacSystemFont, avenir next, avenir, helvetica neue, helvetica, ubuntu, roboto, noto, segoe ui, arial, sans-serif",
-        "fontWeight": "normal",
+        "fontWeight": "100",
         "fontSize": "1.25rem",
         "textTransform": "initial",
         "letterSpacing": "0"


### PR DESCRIPTION
#### What did you change? \*

Define a new `docs.wrapper` interface and pass it as an argument for `around` in the `docs` interface. That way, all of the other interfaces that extend `docs` will already have the `PageLayoutContainer` component around it.

Also, a few layout adjustments.

**Review PR #15 first**

#### Why? \*

This makes the navigation way better, as the components from the `PageLayoutContainer` are not remounted as the page reloads.

#### How to test it? \*

https://victorhmp--vtexpages.myvtex.com/docs/home

#### Types of changes \*

- [x] Bugfix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical improvements
  <!--- * Required -->
