### PR TITLE
Show complete list of components with documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for displaying a complete list of available components on `ComponentsGrid`.
 
 ## [0.20.1] - 2019-08-29
 

--- a/react/ComponentsGrid.tsx
+++ b/react/ComponentsGrid.tsx
@@ -44,8 +44,14 @@ const ComponentsGrid: FC<OuterProps> = ({ ComponentsListQuery }) => {
     route: { params },
   } = useRuntime()
 
-  const componentsListForCategory =
-    ComponentsListQuery.componentsList[params.category]
+  const [category] = params.category.split('-')
+  const shouldShowAllComponents = category === 'all'
+
+  const componentsListFromCategory = shouldShowAllComponents
+    ? Object.keys(ComponentsListQuery.componentsList).flatMap(
+        category => ComponentsListQuery.componentsList[category]
+      )
+    : ComponentsListQuery.componentsList[category]
 
   return (
     <div className="pv9 w-90 center">
@@ -56,19 +62,28 @@ const ComponentsGrid: FC<OuterProps> = ({ ComponentsListQuery }) => {
         <FormattedMessage id="docs/lorem" />
       </p>
       <div className="flex flex-wrap">
-        {componentsListForCategory &&
-          componentsListForCategory.map(component => (
-            <div key={slug(component.title)} className="w-50 w-25-l">
-              <ComponentGridItem
-                title={component.title}
-                description={component.description}
-                link={`${params.category}/${
-                  component.appName
-                }/${(component.file && removeFileExtension(component.file)) ||
-                  ''}`}
-              />
-            </div>
-          ))}
+        {componentsListFromCategory &&
+          componentsListFromCategory.map(component => {
+            const hasTitleAndDescription = !!(
+              component.appName && component.description
+            )
+
+            return (
+              hasTitleAndDescription && (
+                <div key={slug(component.title)} className="w-50 w-30-l">
+                  <ComponentGridItem
+                    title={component.title}
+                    description={component.description}
+                    link={`${params.category}/${
+                      component.appName
+                    }/${(component.file &&
+                      removeFileExtension(component.file)) ||
+                      ''}`}
+                  />
+                </div>
+              )
+            )
+          })}
       </div>
     </div>
   )

--- a/react/package.json
+++ b/react/package.json
@@ -36,8 +36,8 @@
     "react-dom": "^16.8.6",
     "react-intl": "^2.9.0",
     "typescript": "3.5.2",
-    "vtex.render-runtime": "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.render-runtime@8.45.3/public/_types/react",
     "vtex.docs-graphql": "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.docs-graphql@1.5.0/public/_types/react",
+    "vtex.render-runtime": "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.render-runtime@8.45.3/public/_types/react",
     "vtex.store-drawer": "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.store-drawer@0.1.0/public/_types/react",
     "vtex.styleguide": "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.styleguide@9.72.4/public/_types/react"
   }

--- a/react/tsconfig.json
+++ b/react/tsconfig.json
@@ -1,16 +1,10 @@
 {
   "compilerOptions": {
-    "types": [
-      "node",
-      "jest"
-    ],
+    "types": ["node", "jest"],
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "jsx": "react",
-    "lib": [
-      "es2017",
-      "dom"
-    ],
+    "lib": ["es2019", "dom"],
     "module": "es6",
     "moduleResolution": "node",
     "sourceMap": true,
@@ -21,12 +15,6 @@
   "typeAcquisition": {
     "enable": false
   },
-  "include": [
-    "./**/*.tsx",
-    "./typings",
-    "./typings.d.ts"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["./**/*.tsx", "./typings", "./typings.d.ts"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
#### What did you change? \*

Update `ComponentsGrid` component to support displaying all the available components from the list sent by `docs-graphql`.

Also, better support for categories with more than one word, such as `product-related`.

#### Why? \*

We need to be able to show the user a complete view of our component collection.

#### How to test it? \*

https://allcomponents--vtexpages.myvtex.com/docs/components/all

#### Types of changes \*

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical improvements
  <!--- * Required -->
