### PR TITLE
Sidebar and main content have separate scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Independent scrolling on `SideBar` and main content section.
+- Max-width to the `SideBar` to prevent it from stretching on widescreens.
 
 ## [0.21.1] - 2019-08-29
 ### Fixed

--- a/react/PageLayoutContainer.tsx
+++ b/react/PageLayoutContainer.tsx
@@ -19,16 +19,16 @@ const PageLayoutContainer: FC = ({ children }) => {
       </Helmet>
       <div className="flex flex-row-l flex-column min-vh-100">
         <EnhancedAppVersionProvider>
-          <div className="w-25-l min-h-100-l">
+          <div
+            className="w-25-l vh-100-l overflow-y-scroll"
+            style={{ maxWidth: '256px' }}>
             <SideBar />
           </div>
-          <div className="w-100 min-vh-100 h-100">
-            <div className="flex flex-column">
-              <TopNav />
-              <main className="flex w-90-l" style={{ maxWidth: '1024px' }}>
-                {children}
-              </main>
-            </div>
+          <div className="w-100 vh-100 overflow-y-scroll flex flex-column justify-between">
+            <TopNav />
+            <main className="flex w-90-l" style={{ maxWidth: '1024px' }}>
+              {children}
+            </main>
             <Footer />
           </div>
         </EnhancedAppVersionProvider>


### PR DESCRIPTION
#### What did you change? \*

Few layout tweaks to make the navigation better:

- Set a max-width for the `SideBar` component so that it doesn't become too big on widescreens.
- Use `overflow-y-scroll` on both the `SideBar` component and also around the main content container, so that the height of the page is always fixed and these two sections are fully independent.

#### Why? \*

To make the UI better :)

#### How to test it? \*

https://sidebarscroll--vtexpages.myvtex.com/docs/home

#### Types of changes \*

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical improvements
  <!--- * Required -->
