### PR TITLE
Getting started articles should come from `en` locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `GettingStartedArticle` would always query for articles written in Portuguese.
 
 ## [0.23.0] - 2019-08-29
 ### Added

--- a/pages/routes.json
+++ b/pages/routes.json
@@ -1,6 +1,6 @@
 {
   "docs.home": {
-    "path": "/docs/home"
+    "path": "/docs(/home)"
   },
   "docs.recipes-list": {
     "path": "/docs/recipes/:category"

--- a/react/GettingStartedArticle.tsx
+++ b/react/GettingStartedArticle.tsx
@@ -32,7 +32,7 @@ const GettingStartedArticle: FC<OuterProps & InjectedRuntime> = ({
         variables={{
           appName: 'vtex.io-documentation@0.x',
           fileName: `GettingStarted/${track}/${articles[article]}`,
-          locale: 'pt',
+          locale: 'en',
         }}>
         {({
           loading,
@@ -114,7 +114,7 @@ export default compose(
       return {
         variables: {
           track,
-          locale: 'pt',
+          locale: 'en',
         },
       }
     },

--- a/react/Home.tsx
+++ b/react/Home.tsx
@@ -1,5 +1,6 @@
 import React, { FC, Fragment } from 'react'
 import { FormattedMessage, injectIntl, InjectedIntlProps } from 'react-intl'
+import { Link } from 'vtex.render-runtime'
 
 import { slug } from './utils'
 import LatestFeatures from './components/LatestFeatures'
@@ -7,7 +8,6 @@ import Community from './components/Community'
 import ArticleNav from './components/ArticleNav'
 import Recipes from './components/icons/Recipes'
 import Components from './components/icons/Components'
-import Resources from './components/icons/Resources'
 import RightArrow from './components/icons/RightArrow'
 
 const Home: FC<InjectedIntlProps> = ({ intl }) => {
@@ -54,12 +54,12 @@ const Home: FC<InjectedIntlProps> = ({ intl }) => {
                 <FormattedMessage id="docs/lorem-short" />
               </p>
               <div className="flex items-center">
-                <a
-                  href="recipes/style"
+                <Link
+                  to="recipes/style"
                   className="link no-underline c-emphasis">
                   <span className="mr5">See all</span>
                   <RightArrow />
-                </a>
+                </Link>
               </div>
             </div>
             <div className="mh3-l mv8 mv0-l">
@@ -73,29 +73,12 @@ const Home: FC<InjectedIntlProps> = ({ intl }) => {
                 <FormattedMessage id="docs/lorem-short" />
               </p>
               <div className="c-emphasis flex items-center">
-                <a
-                  href="components/general"
+                <Link
+                  to="/docs/components/all"
                   className="link no-underline c-emphasis">
                   <span className="mr5">See all</span>
                   <RightArrow />
-                </a>
-              </div>
-            </div>
-            <div className="mv8 mv0-l">
-              <div className="w-25-l w-10">
-                <Resources />
-              </div>
-              <p className="t-heading-4 ">
-                <FormattedMessage id="docs/resources" />
-              </p>
-              <p className="c-muted-1">
-                <FormattedMessage id="docs/lorem-short" />
-              </p>
-              <div className="c-emphasis flex items-center">
-                <a href="resources" className="link no-underline c-emphasis">
-                  <span className="mr5">See all</span>
-                  <RightArrow />
-                </a>
+                </Link>
               </div>
             </div>
           </div>


### PR DESCRIPTION
#### What did you change? \*

Update the default locale used by the `GettingStartedArticle` component to query for an article.

Update `routes.json` to render `Home` component at `/docs(/home)`.

#### Why? \*

`GettingStartedArticle` would always query for articles written in Portuguese.

#### How to test it? \*

https://docsuigettingstarted--storecomponents.myvtex.com/docs/getting-started/build-stores-with-vtex-io/1

#### Types of changes \*

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical improvements
  <!--- * Required -->
