### PR TITLE
Make sure URLs are always slugified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Slug URLs for better SEO.
 
 ## [0.25.0] - 2019-09-03
 ### Fixed

--- a/react/ComponentsGrid.tsx
+++ b/react/ComponentsGrid.tsx
@@ -102,7 +102,7 @@ const ComponentsGrid: FC<OuterProps> = ({ ComponentsListQuery }) => {
                     link={`/docs/components/${params.category}/${
                       component.appName
                     }/${(component.file &&
-                      removeFileExtension(component.file)) ||
+                      slug(removeFileExtension(component.file))) ||
                       ''}`}
                   />
                 </div>

--- a/react/hooks/useApp.tsx
+++ b/react/hooks/useApp.tsx
@@ -8,9 +8,18 @@ export function useApp() {
 
   const { file } = params
   const { appName, major } = useAppVersionState()
-  const fileName = file || 'README'
+  const fileName = file ? slugToPascal(file) : 'README'
 
   const finalAppName = `${appName}@${major}`
 
   return { appName: finalAppName, fileName }
+}
+
+function slugToPascal(slug: string) {
+  const result = slug
+    .split('-')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join('')
+
+  return result
 }


### PR DESCRIPTION
#### What did you change? \*

Make sure URLs are always slugified.

#### Why? \*

URLs for component docs would not be slugfied, which could hurt our SEO.

#### How to test it? \*

https://docsui--vtexpages.myvtex.com/docs/components/general/vtex.store-components/collection-badges

#### Types of changes \*

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical improvements
  <!--- * Required -->
