### PR TITLE
Fix links from ArticleNav

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Footer links.
+- `ArticleNav` links would do nothing.
 
 ## [0.26.0] - 2019-09-03
 ### Changed

--- a/react/PageLayoutContainer.tsx
+++ b/react/PageLayoutContainer.tsx
@@ -18,7 +18,7 @@ const PageLayoutContainer: FC = ({ children }) => {
         <meta name="description" content="Documentation on VTEX IO" />
         <link rel="icon" href={favicon} />
       </Helmet>
-      <div className="flex flex-row-l flex-column min-vh-100">
+      <div className="flex flex-row-l flex-column vh-100-l">
         <EnhancedAppVersionProvider>
           <EnhancedSideBarContentProvider>
             <div

--- a/react/PageLayoutContainer.tsx
+++ b/react/PageLayoutContainer.tsx
@@ -27,7 +27,9 @@ const PageLayoutContainer: FC = ({ children }) => {
               <SideBar />
             </div>
           </EnhancedSideBarContentProvider>
-          <div className="w-100 vh-100 overflow-y-scroll flex flex-column justify-between">
+          <div
+            className="w-100 min-vh-100 overflow-y-scroll flex flex-column justify-between"
+            style={{ scrollBehavior: 'smooth' }}>
             <TopNav />
             <main className="flex w-90-l" style={{ maxWidth: '1024px' }}>
               {children}

--- a/react/components/ArticleNav.tsx
+++ b/react/components/ArticleNav.tsx
@@ -1,6 +1,5 @@
 import React, { FC, Fragment } from 'react'
 import { FormattedMessage } from 'react-intl'
-import AnchorLink from 'react-anchor-link-smooth-scroll'
 
 import { slug } from '../utils'
 
@@ -20,13 +19,12 @@ const ArticleNav: FC<Props> = ({ headings }) => (
         const slugifiedHeader = slug(heading)
 
         return (
-          <AnchorLink
+          <a
             className="link no-underline"
-            offset={() => 80}
             href={`#${slugifiedHeader}`}
             key={slugifiedHeader}>
             <p className="c-on-base">{heading}</p>
-          </AnchorLink>
+          </a>
         )
       })}
     </Fragment>

--- a/react/components/Footer.tsx
+++ b/react/components/Footer.tsx
@@ -25,16 +25,16 @@ const Footer: FC = () => {
             </div>
             <div className={listItemClasses}>
               <Link
-                to="recipes/style"
+                to="recipes/all"
                 className="link no-underline c-on-base--inverted">
                 <FormattedMessage id="docs/recipes" />
               </Link>
             </div>
             <div className={listItemClasses}>
               <Link
-                to="components/general"
+                to="components/all"
                 className="link no-underline c-on-base--inverted">
-                <FormattedMessage id="docs/components" />
+                <FormattedMessage id="docs/our-components" />
               </Link>
             </div>
             <div className={listItemClasses}>


### PR DESCRIPTION
#### What did you change? \*

Remove `AnchorLink` component from `ArticleNav` in favor of regular `<a>` tags and add `scrollBehavior: 'smooth'` to `main` section of `PageLayoutContainer`.

Also, update links on the `Footer` component.

#### Why? \*

To fix `ArticleNav` links that would do nothing.

#### How to test it? \*

https://articlenavbug--vtexpages.myvtex.com/docs/recipes/layout/using-flex-layout-to-build-your-stores-layout#rules-and-recommendations

#### Types of changes \*

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical improvements
  <!--- * Required -->
