### PR TITLE
Track Page Views in Google Analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## Added
+
+- `google analytics` pageview tracking on `SideBar`
+
 ## [1.0.2] - 2019-09-16
 ### Changed
 - Message `docs/latest-features`.

--- a/react/components/SideBar.tsx
+++ b/react/components/SideBar.tsx
@@ -17,7 +17,7 @@ interface Chapter {
 
 function pageView() {
   if (typeof ga() === 'undefined') {
-    initialize('1')
+    initialize('UA-150301985-1')
   }
   pageview(window.location.pathname + window.location.search)
 }

--- a/react/components/SideBar.tsx
+++ b/react/components/SideBar.tsx
@@ -1,8 +1,8 @@
-import React, { ReactElement, FC } from 'react'
+import React, { ReactElement, FC, useEffect } from 'react'
 import { FormattedMessage } from 'react-intl'
 import { Drawer } from 'vtex.store-drawer'
 import { Link } from 'vtex.render-runtime'
-
+import { initialize, pageview, ga } from 'react-ga'
 import SideBarItem from './SideBarItem'
 import { formatLink } from '../utils'
 import { useSideBarContentState } from './SideBarContext'
@@ -15,9 +15,17 @@ interface Chapter {
   articles: [] | Chapter[]
 }
 
+function pageView() {
+  if (typeof ga() === 'undefined') {
+    initialize('1')
+  }
+  pageview(window.location.pathname + window.location.search)
+}
+
 const SideBar: FC = () => {
   const appName = 'vtex.io-documentation@0.x'
   const { content } = useSideBarContentState()
+  useEffect(() => pageView())
 
   return (
     <nav className="w-100 fixed static-l bg-base z-2 min-h-100-l br-l b--muted-3 flex-l flex-column">


### PR DESCRIPTION
#### What did you change? \*

Track Page Views in docs. The idea was to put the tracking functionality in the SideBar component, because it satisfies 2 properties: 1 - it is rendered one time per page view. 2 - It is rendered in every page view.

#### Why? \*

It is a first step in being able to track the evolution of consumption of the documentation and being able to know what are the most useful pages, what are the ones that need improvement etc
#### How to test it? \*

Use [this](https://gris--vtexpages.myvtex.com/docs) workspace to test it. If you need a google analytics user under the account to be sure that the data is correct, please request it.

#### Types of changes \*

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical improvements
  <!--- * Required -->
