### PR TITLE
Fix sidebar opening more submenus than it should

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Logic when to open sidebar subitems.
 
 ## [1.1.0] - 2019-10-23
-
-## Added
+### Added
 
 - `google analytics` pageview tracking on `SideBar`
 

--- a/react/components/SideBarItem.tsx
+++ b/react/components/SideBarItem.tsx
@@ -31,10 +31,13 @@ const SideBarItem: FC<Props> = ({
 
   const isCurrentSection =
     currentSection &&
+    depth === 0 &&
     (linkSection === currentSection ||
       slug(text.toLowerCase()) === currentSection)
+
   const isCurrentSubsection =
-    currentSubsection && linkSubsection === currentSubsection
+    currentSubsection && depth === 1 && linkSubsection === currentSubsection
+
   const isActive = link === path
 
   const shouldBeOpen = isActive || isCurrentSection || isCurrentSubsection


### PR DESCRIPTION
#### What did you change? \*

Logic of when to open the sidebar menu items.

#### Why? \*

Previously the sidebar had unexpected behaviour.

#### How to test it? \*

1. Open https://breno--iodocs.myvtex.com/docs/
2. Click on Recipes
3. Click on Layout
4. Expect only Layout section to open

--

1. Open https://breno--iodocs.myvtex.com/docs/recipes/store
2. Only Recipes > Store Management should be open

#### Related to / Depends on?

Nope.

#### Types of changes \*

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical improvements
  <!--- * Required -->
