### PR TITLE
Disable HTML escape on DocsRenderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `escapeHtml` set to `true` would render HTML as plain-text.
 
 ## [1.3.0] - 2019-11-18
 ### Added

--- a/react/components/DocsRenderer.tsx
+++ b/react/components/DocsRenderer.tsx
@@ -21,7 +21,7 @@ const DocsRenderer: FC<Props> = ({ markdown, meta }) => {
       <article className="ph0-l ph5 w-100-l w-90 min-vh-100">
         <ReactMarkdown
           source={markdown}
-          escapeHtml
+          escapeHtml={false}
           renderers={CustomRenderers}
           plugins={[emoji]}
         />


### PR DESCRIPTION
#### What did you change? 

Set the value of `escapeHTML` to false on `DocsRenderer` component.

#### Why?

If `escapeHTML` is set to `true`, we lose support for custom `<div>` tags used by `io-documentation`.

#### How to test it? 

https://escapehtmlfix--vtexpages.myvtex.com/docs/recipes/layout/building-a-product-details-page

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical improvements
