### PR TITLE
Use overflow-y-auto to prevent scroll bars to show up when not needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Use `overflow-y-auto` instead of `overflow-y-scroll`.
 
 ## [1.3.1] - 2019-11-27
 ### Fixed

--- a/react/PageLayoutContainer.tsx
+++ b/react/PageLayoutContainer.tsx
@@ -20,13 +20,13 @@ const PageLayoutContainer: FC = ({ children }) => {
       <div className="flex flex-row-l flex-column vh-100-l">
         <EnhancedSideBarContentProvider>
           <div
-            className="w-25-l vh-100-l overflow-y-scroll"
+            className="w-25-l vh-100-l overflow-y-auto"
             style={{ maxWidth: '280px', minWidth: '200px' }}>
             <SideBar />
           </div>
         </EnhancedSideBarContentProvider>
         <div
-          className="w-100 min-vh-100 overflow-y-scroll flex flex-column justify-between"
+          className="w-100 min-vh-100 overflow-y-auto flex flex-column justify-between"
           style={{ scrollBehavior: 'smooth' }}>
           <TopNav />
           {children}

--- a/react/PageLayoutContainer.tsx
+++ b/react/PageLayoutContainer.tsx
@@ -21,7 +21,7 @@ const PageLayoutContainer: FC = ({ children }) => {
         <EnhancedSideBarContentProvider>
           <div
             className="w-25-l vh-100-l overflow-y-auto"
-            style={{ maxWidth: 280, minWidth: 200 }}>
+            style={{ maxWidth: '280px', minWidth: '200px' }}>
             <SideBar />
           </div>
         </EnhancedSideBarContentProvider>

--- a/react/PageLayoutContainer.tsx
+++ b/react/PageLayoutContainer.tsx
@@ -21,7 +21,7 @@ const PageLayoutContainer: FC = ({ children }) => {
         <EnhancedSideBarContentProvider>
           <div
             className="w-25-l vh-100-l overflow-y-auto"
-            style={{ maxWidth: '280px', minWidth: '200px' }}>
+            style={{ maxWidth: 280, minWidth: 200 }}>
             <SideBar />
           </div>
         </EnhancedSideBarContentProvider>


### PR DESCRIPTION
#### What did you change?

Replace `overflow-y-scroll` by `overflow-y-auto`.

#### Why?

So that the scroll bar does not show up when not needed.

#### How to test it?

[Workspace](https://overflowfix--vtexpages.myvtex.com/docs/)

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical improvements
  <!--- * Required -->
