### PR TITLE
Prevent ordered list indexes from being restarted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Ordered list indexes being reset during rendering of the markdown content.
 
 ## [1.3.3] - 2019-12-02
 

--- a/react/components/CustomTags.tsx
+++ b/react/components/CustomTags.tsx
@@ -156,7 +156,9 @@ export const CustomRenderers = {
   list: (props: any) => {
     if (props.ordered) {
       return (
-        <ol className="t-body c-on-base mt0 mb6 pl6 lh-copy">
+        <ol
+          start={props.start}
+          className="t-body c-on-base mt0 mb6 pl6 lh-copy">
           {props.children}
         </ol>
       )


### PR DESCRIPTION
#### What did you change?

Add a `start` property to the custom rendered `ol` tag which should prevent it from resetting when different lists are used in the Markdown.

#### Why?

To prevent ordered list indexes from being reset to 1.

#### How to test it? \*

https://docsuilists--vtexpages.myvtex.com/docs/recipes/layout/configuring-custom-images-for-the-sku-selector

#### Types of changes \*

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical improvements
