### PR TITLE
Fix layout components page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Broken `/docs/components/layout` page.
 
 ## [1.4.0] - 2019-12-27
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -40,6 +40,8 @@
   "docs/recipes.all-description": "All the answers to any platform related questions can be found here! Find all the recipes for VTEX IO functionalities below:",
   "docs/recipes.app": "Apps Recipes",
   "docs/read-more": "Read more",
+  "docs/components.layout": "Layout Components",
+  "docs/components.layout-description": "Check out our most flexible components to add different layout elements into your store.",
   "docs/components.general": "General Components",
   "docs/components.general-description": "The entire online store interface is made up of several different components. Explore the list of available components your store can already use here.",
   "docs/components.navigation": "Navigation Components",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -40,6 +40,8 @@
   "docs/recipes.all-description": "All the answers to any platform related questions can be found here! Find all the recipes for VTEX IO functionalities below:",
   "docs/recipes.app": "Apps Recipes",
   "docs/read-more": "Read more",
+  "docs/components.layout": "Layout Components",
+  "docs/components.layout-description": "Check out our most flexible components to add different layout elements into your store.",
   "docs/components.general": "General Components",
   "docs/components.general-description": "The entire online store interface is made up of several different components. Explore the list of available components your store can already use here.",
   "docs/components.navigation": "Navigation Components",

--- a/react/ComponentsGrid.tsx
+++ b/react/ComponentsGrid.tsx
@@ -13,6 +13,14 @@ import ComponentList from './graphql/componentsList.graphql'
 import Skeleton from './components/Skeleton'
 
 defineMessages({
+  layout: {
+    id: 'docs/components.layout',
+    defaultMessage: '',
+  },
+  layoutDescription: {
+    id: 'docs/components.layout-description',
+    defaultMessage: '',
+  },
   general: {
     id: 'docs/components.general',
     defaultMessage: '',

--- a/react/graphql/componentsList.graphql
+++ b/react/graphql/componentsList.graphql
@@ -1,5 +1,12 @@
 query componentsList($appName: String, $locale: String) {
   componentsList(appName: $appName, locale: $locale) {
+    layout {
+      appName
+      file
+      title
+      description
+      url
+    }
     general {
       appName
       file


### PR DESCRIPTION
#### What did you change?

Added missing messages for `docs/components/layout` page and update GraphQL query to get these components.

#### Why?

The page was broken 🥺

#### How to test it? \*

[Workspace](https://layoutcomponentsfix--vtexpages.myvtex.com/docs/components/layout)

#### Related to / Depends on?

Depends on: https://github.com/vtex/docs-graphql/pull/12

#### Types of changes \*

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical improvements
