### PR TITLE
Parse headline by splitting #

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Parsed markdown headlines by #
+
 ## [1.4.5] - 2020-01-13
 
 ### Updated

--- a/react/components/DocsRenderer.tsx
+++ b/react/components/DocsRenderer.tsx
@@ -9,10 +9,12 @@ import { Helmet } from 'vtex.render-runtime'
 
 const DocsRenderer: FC<Props> = ({ markdown, meta }) => {
   const isEmptyDocs = markdown === ''
+
   const title = markdown
-    .split('\n')[0]
-    .replace('#', '')
+    .split('# ')[1] // everything after the #
+    .split('\n')[0] // Only the headline
     .trim()
+
   return !isEmptyDocs ? (
     <Fragment>
       <Helmet>


### PR DESCRIPTION
#### What did you change? \*

<!--- Describe your changes in detail. -->
Parse title of pages correctly

#### Why? \*

So that the headline can be used as the html title of the page

#### How to test it? \*
https://gris--vtexpages.myvtex.com/docs/components/product/vtex.store-components/buy-button
<!--- Link to a running workspace with some steps to reproduce it or even a screenshot of before/after -->

#### Related to / Depends on?

<!--- Link to an issue or clubhouse task that did motivate this PR or even others PRs that this one depends. -->

#### Types of changes \*

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical improvements
  <!--- * Required -->
