### PR TITLE
Fix search behavior without query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- search behavior when no query string is provided
 
 ## [1.5.0] - 2020-01-16
 

--- a/react/Search.tsx
+++ b/react/Search.tsx
@@ -40,47 +40,51 @@ const Search: FC<Props> = ({ query }) => {
     <Fragment>
       {isMobile && <SearchBar />}
       {!loading ? (
-        <div className={`pv6 w-100 flex flex-column`}>
-          <h1
-            className={`t-heading-1 right ph6 ${isMobile ? '' : 'center'}`}
-            style={{ fontSize: `${isMobile ? '24px' : '48px'}` }}>
-            {results.length > 0
-              ? `Results for "${queryString}"`
-              : 'No Results Found'}
-          </h1>
+        queryString && (
+          <div className={`pv6 w-100 flex flex-column`}>
+            <h1
+              className={`t-heading-1 right ph6 ${isMobile ? '' : 'center'}`}
+              style={{ fontSize: `${isMobile ? '24px' : '48px'}` }}>
+              {results.length > 0
+                ? `Results for "${queryString}"`
+                : 'No Results Found'}
+            </h1>
 
-          {results && (
-            <ul className="w-100 list pl0 center mw8">
-              {results.map((result: SearchResult, index: number) => (
-                <li
-                  key={index}
-                  className={`mh8 ${
-                    isFirstResult(index) ? '' : 'mv8'
-                  } searchResult ${
-                    isNotLastResult(results, index) ? 'searchResultBorder' : ''
-                  }`}>
-                  <h2
-                    className="t-heading-2 searchTitle"
-                    style={{ wordBreak: 'break-word' }}>
-                    {result.title}
-                  </h2>
-                  <p className="t-body searchSnippet">{result.snippet}</p>
-                  <a
-                    className={`link c-emphasis no-underline t-body ml-auto
+            {results && (
+              <ul className="w-100 list pl0 center mw8">
+                {results.map((result: SearchResult, index: number) => (
+                  <li
+                    key={index}
+                    className={`mh8 ${
+                      isFirstResult(index) ? '' : 'mv8'
+                    } searchResult ${
+                      isNotLastResult(results, index)
+                        ? 'searchResultBorder'
+                        : ''
+                    }`}>
+                    <h2
+                      className="t-heading-2 searchTitle"
+                      style={{ wordBreak: 'break-word' }}>
+                      {result.title}
+                    </h2>
+                    <p className="t-body searchSnippet">{result.snippet}</p>
+                    <a
+                      className={`link c-emphasis no-underline t-body ml-auto
                 flex items-center dim`}
-                    href={result.link}>
-                    <div className="flex flex-column flex-row di">
-                      <span>Read More</span>
-                      <div className="ml5">
-                        <RightArrow />
+                      href={result.link}>
+                      <div className="flex flex-column flex-row di">
+                        <span>Read More</span>
+                        <div className="ml5">
+                          <RightArrow />
+                        </div>
                       </div>
-                    </div>
-                  </a>
-                </li>
-              ))}
-            </ul>
-          )}
-        </div>
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )
       ) : (
         <Skeleton />
       )}


### PR DESCRIPTION
#### What did you change? \*

When there is no query string passed to docs/search don't render 'no results found'


#### How to test it? \*
https://gris--vtexpages.myvtex.com/docs/search
<!--- Link to a running workspace with some steps to reproduce it or even a screenshot of before/after -->

#### Related to / Depends on?

<!--- Link to an issue or clubhouse task that did motivate this PR or even others PRs that this one depends. -->

#### Types of changes \*

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical improvements
  <!--- * Required -->
