### PR TITLE
Using replace and changing the effect of the provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Fixed
 - Using `replace` when navigating to app's specific version.
+- Updating Sidebar verification if the current link is on.
 
 ## [1.11.0] - 2020-03-24
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Using `replace` when navigating to app's specific version.
 
 ## [1.11.0] - 2020-03-24
 ### Added

--- a/react/components/AppVersionContext.tsx
+++ b/react/components/AppVersionContext.tsx
@@ -131,8 +131,9 @@ const EnhancedAppVersionProvider: FC = ({ children }) => {
     navigate({
       page: route.id,
       params: { ...currentParams, app: updatedApp },
+      replace: true
     })
-  }, [app, appName, data])
+  }, [data])
 
   if (loading) {
     return null

--- a/react/components/SideBarItem.tsx
+++ b/react/components/SideBarItem.tsx
@@ -38,7 +38,7 @@ const SideBarItem: FC<Props> = ({
   const isCurrentSubsection =
     currentSubsection && depth === 1 && linkSubsection === currentSubsection
 
-  const isActive = link === path
+  const isActive = path.includes(link!)
 
   const shouldBeOpen = isActive || isCurrentSection || isCurrentSubsection
 


### PR DESCRIPTION
Fixing a bug I've introduced earlier, where the user had to go back twice to go back one time.

Running in https://templo--vtexpages.myvtex.com/docs