### PR TITLE
Custom Header Settings on Settings Schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `customHeader` as a setting in `settingsSchema`
 
 ## [1.11.1] - 2020-03-24
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -22,6 +22,19 @@
   "registries": [
     "smartcheckout"
   ],
-  "settingsSchema": {},
+  "settingsSchema": {
+    "title": "DOCS-UI",
+    "type": "object",
+    "properties": {
+      "customHeader": {
+        "title": "Custom Header",
+        "type": "object",
+        "properties": {
+          "key": { "type": "string" },
+          "value": { "type": "string" }
+        }
+      }
+    }
+  },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }


### PR DESCRIPTION
#### What did you change? \*

<!--- Describe your changes in detail. -->
Added a Custom Header on Settings Schema

#### Why? \*
To be able to set headers in docs-ui. More specifically, I want to be able to render docs-ui as an `iframe` in [developers.vtex.com](url)

#### Types of changes \*

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical improvements
  <!--- * Required -->
