### PR TITLE
Fixing navigation issues (about file extension and trailing slash)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Always adding trailing slash to URLs
+- Filename with duplicated extension .md
 
 ## [1.12.0] - 2020-03-30
 ### Added

--- a/react/AppDocs.tsx
+++ b/react/AppDocs.tsx
@@ -6,6 +6,7 @@ import DocsRenderer from './components/DocsRenderer'
 import Skeleton from './components/Skeleton'
 import EmptyDocs from './components/EmptyDocs'
 import { useApp } from './hooks/useApp'
+import { maybeAddMdExtension } from './utils'
 import MarkdownFile from './graphql/markdownFile.graphql'
 
 const AppDocs: FC = () => {
@@ -17,7 +18,7 @@ const AppDocs: FC = () => {
         query={MarkdownFile}
         variables={{
           appName,
-          fileName: `${fileName}.md`,
+          fileName: maybeAddMdExtension(fileName),
         }}>
         {({
           loading,

--- a/react/ComponentsGrid.tsx
+++ b/react/ComponentsGrid.tsx
@@ -5,16 +5,9 @@ import { useRuntime } from 'vtex.render-runtime'
 
 import ComponentGridItem from './components/ComponentGridItem'
 import EmptyDocs from './components/EmptyDocs'
-import { slug } from './utils'
+import { slug, removeFileExtension } from './utils'
 import { IO_DOCUMENTATION } from './utils/constants'
 import ComponentList from './graphql/componentsList.graphql'
-
-function removeFileExtension(fileName: string) {
-  const MARKDOWN_EXTENSION = '.md'
-  return fileName.endsWith(MARKDOWN_EXTENSION)
-    ? fileName.substring(0, fileName.length - MARKDOWN_EXTENSION.length)
-    : fileName
-}
 
 const ComponentsGrid: FC = () => {
   const {

--- a/react/Concept.tsx
+++ b/react/Concept.tsx
@@ -7,6 +7,7 @@ import { IO_DOCUMENTATION } from './utils/constants'
 import DocsRenderer from './components/DocsRenderer'
 import Skeleton from './components/Skeleton'
 import EmptyDocs from './components/EmptyDocs'
+import { maybeAddMdExtension } from './utils'
 import MarkdownFile from './graphql/markdownFile.graphql'
 
 const Concept: FC = () => {
@@ -20,7 +21,7 @@ const Concept: FC = () => {
         query={MarkdownFile}
         variables={{
           appName: IO_DOCUMENTATION,
-          fileName: `Concepts/${params.concept}.md`,
+          fileName: `Concepts/${maybeAddMdExtension(params.concept)}`,
           locale: 'en',
         }}>
         {({

--- a/react/IntroductionArticle.tsx
+++ b/react/IntroductionArticle.tsx
@@ -7,6 +7,7 @@ import DocsRenderer from './components/DocsRenderer'
 import Skeleton from './components/Skeleton'
 import EmptyDocs from './components/EmptyDocs'
 import { IO_DOCUMENTATION } from './utils/constants'
+import { maybeAddMdExtension } from './utils'
 import MarkdownFile from './graphql/markdownFile.graphql'
 
 const IntroductionArticle: FC = () => {
@@ -20,7 +21,7 @@ const IntroductionArticle: FC = () => {
         query={MarkdownFile}
         variables={{
           appName: IO_DOCUMENTATION,
-          fileName: `Introduction/${params.article}.md`,
+          fileName: `Introduction/${maybeAddMdExtension(params.article)}`,
           locale: 'en',
         }}>
         {({

--- a/react/Recipe.tsx
+++ b/react/Recipe.tsx
@@ -7,6 +7,7 @@ import DocsRenderer from './components/DocsRenderer'
 import Skeleton from './components/Skeleton'
 import EmptyDocs from './components/EmptyDocs'
 import { IO_DOCUMENTATION } from './utils/constants'
+import { maybeAddMdExtension } from './utils'
 import MarkdownFile from './graphql/markdownFile.graphql'
 
 const Recipe: FC = () => {
@@ -20,7 +21,9 @@ const Recipe: FC = () => {
         query={MarkdownFile}
         variables={{
           appName: IO_DOCUMENTATION,
-          fileName: `Recipes/${params.category}/${params.recipe}.md`,
+          fileName: `Recipes/${params.category}/${maybeAddMdExtension(
+            params.recipe
+          )}`,
           locale: 'en',
         }}>
         {({

--- a/react/ReleaseArticle.tsx
+++ b/react/ReleaseArticle.tsx
@@ -6,6 +6,7 @@ import { useRuntime } from 'vtex.render-runtime'
 import DocsRenderer from './components/DocsRenderer'
 import Skeleton from './components/Skeleton'
 import EmptyDocs from './components/EmptyDocs'
+import { maybeAddMdExtension } from './utils'
 import MarkdownFile from './graphql/markdownFile.graphql'
 
 const ReleaseArticle: FC = () => {
@@ -19,7 +20,7 @@ const ReleaseArticle: FC = () => {
         query={MarkdownFile}
         variables={{
           appName: 'vtex.io-release-notes@0.x',
-          fileName: `${params.week}/${params.article}.md`,
+          fileName: `${params.week}/${maybeAddMdExtension(params.article)}`,
         }}>
         {({
           loading,

--- a/react/components/AppVersionContext.tsx
+++ b/react/components/AppVersionContext.tsx
@@ -118,8 +118,22 @@ const EnhancedAppVersionProvider: FC = ({ children }) => {
     },
   })
 
+  // Just a bit hacky: It always check if the url has a trailing slash, setting it if not.
+  // It's useful for README's that link to other files
   useEffect(() => {
-    if (!app || appVersionFromUrl || !data?.appVersions) {
+    if (!appVersionFromUrl || route.path.endsWith('/')){
+      return
+    }
+    navigate({
+      to: route.path + '/',
+      replace: true,
+      preventRemount: true
+    })
+  }, [route.path])
+
+  // Always set the app's version on the URL (except io-documentation)
+  useEffect(() => {
+    if (!app || appVersionFromUrl || !data?.appVersions?.latestStable) {
       return
     }
     const { params: currentParams } = route

--- a/react/components/Footer.tsx
+++ b/react/components/Footer.tsx
@@ -37,13 +37,6 @@ const Footer: FC = () => {
                 <FormattedMessage id="docs/our-components" />
               </Link>
             </div>
-            <div className={listItemClasses}>
-              <Link
-                to="resources"
-                className="link no-underline c-on-base--inverted dim">
-                <FormattedMessage id="docs/resources" />
-              </Link>
-            </div>
           </div>
           <div className="list">
             <div className={listItemClasses}>

--- a/react/utils/index.ts
+++ b/react/utils/index.ts
@@ -1,5 +1,7 @@
 import slugify from 'slugify'
 
+const MARKDOWN_EXTENSION = '.md'
+
 function slug(str: string) {
   const replaced =
     (typeof str === 'string' && str.replace(/[*+~.()'"!:@&[\]]/g, '')) || ''
@@ -19,7 +21,6 @@ function formatLink(path: string) {
 }
 
 function removeFileExtension(fileName: string) {
-  const MARKDOWN_EXTENSION = '.md'
   const hasExtension = fileName.endsWith(MARKDOWN_EXTENSION)
 
   return !hasExtension
@@ -27,4 +28,10 @@ function removeFileExtension(fileName: string) {
     : fileName.substring(0, fileName.length - MARKDOWN_EXTENSION.length)
 }
 
-export { slug, formatLink, removeFileExtension }
+function maybeAddMdExtension(fileName: string) {
+  return fileName.endsWith(MARKDOWN_EXTENSION)
+    ? fileName
+    : `${fileName}${MARKDOWN_EXTENSION}`
+}
+
+export { slug, formatLink, removeFileExtension, maybeAddMdExtension }


### PR DESCRIPTION
Test here: https://templo--vtexpages.myvtex.com/docs

We were having some some problems with DocsUI urls, this PR tries to fix it.

- [x] Sometimes, the query to backend would go with filename `InfoCard.md.md` because of some concatenations. Fixed it with a check.

- [x] The lack of a trailing slash (`/`) on the URL causes some docs to link to invalid URL's (e.g: vtex.store-components). 

- [x] Removing `documentos / recursos` option from Footer menu