### PR TITLE
Fix links with docs in the route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- fix a few links that were not moved from `docs` to `docs-ui`
 
 ## [2.0.0] - 2020-04-15
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- fix a few links that were not moved from `docs` to `docs-ui`
+- Fix a few links that were not moved from `docs` to `docs-ui`
 
 ## [2.0.0] - 2020-04-15
 ### Changed

--- a/react/components/LatestFeatures.tsx
+++ b/react/components/LatestFeatures.tsx
@@ -53,7 +53,7 @@ const LatestFeatures: FC = () => {
       </div>
       <div className="flex items-center mv5">
         <Link
-          page="docs.release-notes"
+          page="docs-ui.release-notes"
           className="link no-underline c-emphasis mv5 dim">
           <span className="mr5">
             <FormattedMessage id="docs-ui/see-previous-releases" />

--- a/react/components/SearchBar.tsx
+++ b/react/components/SearchBar.tsx
@@ -14,7 +14,7 @@ const SearchBar: FC = () => {
     e.preventDefault()
     if (inputString !== '') {
       navigate({
-        page: 'docs.search',
+        page: 'docs-ui.search',
         query: `q=${inputString}`,
         fetchPage: true,
       })


### PR DESCRIPTION
#### What did you change? \*

<!--- Describe your changes in detail. -->
Fixing links from `docs` to `docs-ui`

#### Why? \*
Because they stopped working

<!--- What is the motivation and context for this change? -->

#### How to test it? \*

<!--- Link to a running workspace with some steps to reproduce it or even a screenshot of before/after -->
https://gris--vtexpages.myvtex.com/docs

#### Related to / Depends on?

<!--- Link to an issue or clubhouse task that did motivate this PR or even others PRs that this one depends. -->
https://github.com/vtex-apps/docs-ui/pull/86

#### Types of changes \*

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical improvements
  <!--- * Required -->
