### PR TITLE
Change around logic to leave docs-ui without navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
-- moved the `around` logic to more specific interfaces
-- Removed `docs-ui.concepts` from `interfaces.json`
-- Renamed `docs-wrapper` to `navigation-wrapper`
+- Moved the `around` logic to more specific interfaces.
+- Renamed `docs-wrapper` to `navigation-wrapper`.
+
+### Removed
+- `docs-ui.concepts` from `interfaces.json`.
 
 ## [2.0.2] - 2020-04-15
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- moved the `around` logic to more specific interfaces
+- Removed `docs-ui.concepts` from `interfaces.json`
+- Renamed `docs-wrapper` to `navigation-wrapper`
 
 ## [2.0.2] - 2020-04-15
 ### Fixed

--- a/pages/interfaces.json
+++ b/pages/interfaces.json
@@ -1,59 +1,71 @@
 {
-  "docs-wrapper": {
+  "navigation-wrapper": {
     "component": "PageLayoutContainer"
   },
   "docs-ui": {
-    "around": ["docs-wrapper"]
   },
   "docs-ui.home": {
+    "around": ["navigation-wrapper"],
     "component": "Home"
   },
   "docs-ui.search": {
+    "around": ["navigation-wrapper"],
     "component": "Search"
   },
   "docs-ui.app": {
+    "around": ["navigation-wrapper"],
     "component": "AppDocs"
   },
   "docs-ui.construction": {
+    "around": ["navigation-wrapper"],
     "component": "UnderConstruction"
   },
   "docs-ui.recipes-list": {
+    "around": ["navigation-wrapper"],
     "component": "RecipesList"
   },
   "docs-ui.recipe": {
+    "around": ["navigation-wrapper"],
     "component": "Recipe"
   },
   "docs-ui.components-list": {
+    "around": ["navigation-wrapper"],
     "component": "ComponentsGrid"
   },
   "docs-ui.apps-list": {
+    "around": ["navigation-wrapper"],
     "component": "ComponentsGrid"
   },
   "docs-ui.component": {
+    "around": ["navigation-wrapper"],
     "component": "AppDocs"
   },
   "docs-ui.apps": {
+    "around": ["navigation-wrapper"],
     "component": "AppDocs"
   },
   "docs-ui.concept-list": {
+    "around": ["navigation-wrapper"],
     "component": "ConceptList"
   },
   "docs-ui.concept": {
+    "around": ["navigation-wrapper"],
     "component": "Concept"
   },
   "docs-ui.release-notes": {
+    "around": ["navigation-wrapper"],
     "component": "ReleaseNotes"
   },
   "docs-ui.release-article": {
+    "around": ["navigation-wrapper"],
     "component": "ReleaseArticle"
   },
   "docs-ui.getting-started": {
+    "around": ["navigation-wrapper"],
     "component": "GettingStartedArticle"
   },
   "docs-ui.introduction": {
+    "around": ["navigation-wrapper"],
     "component": "IntroductionArticle"
-  },
-  "docs-ui.concepts": {
-    "component": "ConceptsList"
   }
 }


### PR DESCRIPTION
#### What did you change? \*

<!--- Describe your changes in detail. -->
This PR does the following:
- move the around logic to more specific interfaces
- rename the `docs-wrapper` interface to `navigation-wrapper`
- removes the `docs-ui.concepts` interface (which was unused, the one that is being used is `docs-ui.concept-list`
  
 #### Why? \*

<!--- What is the motivation and context for this change? -->
To enable a new interface that is going to be created for the doc prop to have the domain `docs-ui` without having the navigation. It will be used as an iframe in the [developer docs](developers.vtex.com)

#### How to test it? \*

<!--- Link to a running workspace with some steps to reproduce it or even a screenshot of before/after -->
https://stoa--vtexpages.myvtex.com/docs/

#### Types of changes \*

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical improvements
  <!--- * Required -->
