### PR TITLE
Fix /apps/content-blocks/ and /apps/functional content not being rendered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Component grid would be rendered empty due to a variable being passed to the ComponentList query with the wrong value.
 
 ## [2.0.3] - 2020-04-22
 ### Changed

--- a/react/ComponentsGrid.tsx
+++ b/react/ComponentsGrid.tsx
@@ -15,7 +15,7 @@ const ComponentsGrid: FC = () => {
     page,
   } = useRuntime()
 
-  const useAppsDirectory = page === 'docs.apps-list'
+  const useAppsDirectory = page === 'docs-ui.apps-list'
 
   const { data, error, loading } = useQuery<{
     componentsList: Record<


### PR DESCRIPTION
#### What did you change? \*

Update logic responsible for setting the `useAppsDirectory` variable used by `ComponentsGrid` component.

#### Why?

The value computed for this variable was always `false`, which resulted in the `ComponentsGrid` component not being rendered since the `ComponentList` query was returning `null`.

#### How to test it? \*

https://docsui--vtexpages.myvtex.com/docs/apps/content-blocks/
https://docsui--vtexpages.myvtex.com/docs/apps/functional/

#### Types of changes \*

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical improvements