### PR TITLE
Fix syntax highlight for JSONC snippets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- JSONC code snippets would not have sintax highlight.
 
 ## [2.1.0] - 2020-05-05
 ### Added

--- a/react/components/CodeBlock.tsx
+++ b/react/components/CodeBlock.tsx
@@ -14,9 +14,12 @@ const CodeBlock: FC<Props> = ({ language, value }) => {
     }
   }, [codeBlockRef])
 
+  // highlight.js does not support `.jsonc` files
+  const codeBlockLanguage = language === 'jsonc' ? 'json' : language
+
   return (
     <pre>
-      <code ref={codeBlockRef} className={`language-${language}`}>
+      <code ref={codeBlockRef} className={`language-${codeBlockLanguage}`}>
         {value}
       </code>
     </pre>


### PR DESCRIPTION
#### What did you change?

Update the `CodeBlock` component to treat JSONC snippets as if they were JSON snippets, applying the correct syntax hightlighting.

#### Why?

`highlight.js` does not support JSONC, so these snippets would be rendered without any highlights.

#### How to test it?

1. Go to the [documentation page for the `vtex.minicart` app](https://vtex.io/docs/app/vtex.minicart);
2. Scroll down to the "Advanced Configuration" section and you should see a big snippet without any syntax highlighting 😢 ;
3. Now go to this [workspace](https://victormiranda--vtexpages.myvtex.com/docs/app/vtex.minicart) and the same code snippet should be looking much better ✨ .

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical improvements
