### PR TITLE
Prevent search results from containing version numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Search results pointing to urls with fixed version numbers, which might be outdated.
 
 ## [2.1.2] - 2020-06-24
 ### Fixed

--- a/react/Search.tsx
+++ b/react/Search.tsx
@@ -26,6 +26,14 @@ const isNotLastResult = (results: SearchResult[], index: number) =>
 
 const isFirstResult = (index: number) => index === 0
 
+const removeAppVersionFromSearchResult = (url: string) => {
+  // https://regex101.com/r/gbllfu/1
+  const versionRegex = /@[\d.]+/g
+  const containsAppVersion = versionRegex.test(url)
+
+  return containsAppVersion ? url.replace(versionRegex, '') : url
+}
+
 const Search: FC<Props> = ({ query }) => {
   const queryString = query.q || ''
 
@@ -67,7 +75,7 @@ const Search: FC<Props> = ({ query }) => {
                     <a
                       className={`link c-emphasis no-underline t-body ml-auto
                 flex items-center dim`}
-                      href={result.link}>
+                      href={removeAppVersionFromSearchResult(result.link)}>
                       <div className="flex flex-column flex-row di">
                         <span>Read More</span>
                         <div className="ml5">


### PR DESCRIPTION
#### What did you change?

Added a bit of logic to prevent search results from redirecting users to outdated documentation, by removing any version numbers those results might include.

#### Why?

To prevent users from consuming outdated documentation without knowing.

#### How to test it?

Here is a linked [workspace](https://victormiranda--vtexpages.myvtex.com/docs/search?q=add-to-cart-button) with this change. Compare it to the same search performed in [`master`](https://vtex.io/docs/search?q=add-to-cart-button/) workspace. Notice that you no longer get a result that points to `vtex.add-to-cart-button@0.9.0`, but instead points to an address without a version number, which would always take you to the latest one.

#### Types of changes \*

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical improvements
